### PR TITLE
Add PHPStan, PHPCS, and composer QA scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 Makefile
 /vendor/
 .phpunit.result.cache
+.phpcs.cache

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,35 @@
             "homepage": "https://github.com/Respect/Data/graphs/contributors"
         }
     ],
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "require": {
         "php": ">=8.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0"
+        "phpstan/phpstan": "^2.0",
+        "phpunit/phpunit": "^10.0",
+        "respect/coding-standard": "^5.0",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "Respect\\": "library/Respect"
         }
+    },
+    "scripts": {
+        "phpcs": "vendor/bin/phpcs",
+        "phpstan": "vendor/bin/phpstan analyze",
+        "phpunit": "vendor/bin/phpunit",
+        "qa": [
+            "@phpcs",
+            "@phpstan",
+            "@phpunit"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset
+    name="PHPCS Coding Standards for Respect/Data"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="." />
+    <arg name="cache" value=".phpcs.cache" />
+    <arg name="colors" />
+    <arg name="extensions" value="php" />
+    <arg value="p" />
+    <arg value="s" />
+
+    <file>library/</file>
+    <file>tests/</file>
+
+    <rule ref="Respect" />
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+parameters:
+  level: 1
+  paths:
+    - library/
+    - tests/
+  ignoreErrors:
+    - message: '/Call to an undefined static method Respect\\Data\\Collections\\(Collection|Filtered|Mix|Typed)::\w+\(\)\./'
+    - message: '/Call to an undefined method Respect\\Data\\AbstractMapper::\w+\(\)\./'
+    - message: '/Unsafe usage of new static\(\)\./'


### PR DESCRIPTION
Add static analysis (PHPStan level 1) and code style checking (PHPCS with respect/coding-standard) as dev dependencies. Configure composer scripts for phpcs, phpstan, phpunit, and qa. PHPStan ignores are set for magic method patterns (__callStatic, __call, new static()) that are by-design in this project.