### PR TITLE
Move to src/ layout, add strict_types, add PHPStan to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,30 +6,24 @@ on:
   pull_request:
 
 jobs:
-  test:
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: [ '8.5' ]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.5'
+      - uses: ramsey/composer-install@v3
+      - run: composer phpunit
 
-      - name: Get composer cache
-        uses: actions/cache@v4
+  static-analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
         with:
-          path: ~/.cache/composer
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --no-interaction
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit --configuration phpunit.xml.dist
+          php-version: '8.5'
+      - uses: ramsey/composer-install@v3
+      - run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Respect\\": "library/Respect"
+            "Respect\\Data\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Respect\\Data\\": "tests/"
         }
     },
     "scripts": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
     <arg value="p" />
     <arg value="s" />
 
-    <file>library/</file>
+    <file>src/</file>
     <file>tests/</file>
 
     <rule ref="Respect" />

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,9 @@
 parameters:
-  level: 1
+  level: 2
   paths:
-    - library/
+    - src/
     - tests/
   ignoreErrors:
-    - message: '/Call to an undefined static method Respect\\Data\\Collections\\(Collection|Filtered|Mix|Typed)::\w+\(\)\./'
-    - message: '/Call to an undefined method Respect\\Data\\AbstractMapper::\w+\(\)\./'
+    - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|Collections\\(Collection|Filtered|Mix|Typed))::\w+\(\)\./'
+    - message: '/Access to an undefined property Respect\\Data\\Collections\\Collection::\$\w+\./'
     - message: '/Unsafe usage of new static\(\)\./'

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data;
 
 use RecursiveArrayIterator;

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 use Respect\Data\AbstractMapper;

--- a/src/Collections/Filterable.php
+++ b/src/Collections/Filterable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 interface Filterable

--- a/src/Collections/Filtered.php
+++ b/src/Collections/Filtered.php
@@ -1,21 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
-class Typed extends Collection
+class Filtered extends Collection
 {
     public static function __callStatic($name, $children)
     {
         $collection = new self();
-        $collection->extra('type', '');
+        $collection->extra('filters', array());
 
         return $collection->__call($name, $children);
     }
 
-    public static function by($type)
+    public static function by($name)
     {
         $collection = new Collection();
-        $collection->extra('type', $type);
+        $collection->extra('filters', func_get_args());
 
         return $collection;
     }

--- a/src/Collections/Mix.php
+++ b/src/Collections/Mix.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 class Mix extends Collection

--- a/src/Collections/Mixable.php
+++ b/src/Collections/Mixable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 interface Mixable

--- a/src/Collections/Typable.php
+++ b/src/Collections/Typable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 interface Typable

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -1,21 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
-class Filtered extends Collection
+class Typed extends Collection
 {
     public static function __callStatic($name, $children)
     {
         $collection = new self();
-        $collection->extra('filters', array());
+        $collection->extra('type', '');
 
         return $collection->__call($name, $children);
     }
 
-    public static function by($name)
+    public static function by($type)
     {
         $collection = new Collection();
-        $collection->extra('filters', func_get_args());
+        $collection->extra('type', $type);
 
         return $collection;
     }

--- a/src/Styles/AbstractStyle.php
+++ b/src/Styles/AbstractStyle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 abstract class AbstractStyle implements Stylable

--- a/src/Styles/CakePHP.php
+++ b/src/Styles/CakePHP.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 class CakePHP extends Standard

--- a/src/Styles/NorthWind.php
+++ b/src/Styles/NorthWind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 class NorthWind extends Standard

--- a/src/Styles/Plural.php
+++ b/src/Styles/Plural.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 /**

--- a/src/Styles/Sakila.php
+++ b/src/Styles/Sakila.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 class Sakila extends Standard

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 class Standard extends AbstractStyle

--- a/src/Styles/Stylable.php
+++ b/src/Styles/Stylable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Styles;
 
 interface Stylable

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;

--- a/tests/CollectionIteratorTest.php
+++ b/tests/CollectionIteratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
 class CollectionTest extends \PHPUnit\Framework\TestCase

--- a/tests/Collections/FilteredTest.php
+++ b/tests/Collections/FilteredTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
-class TypedTest extends \PHPUnit\Framework\TestCase
+class FilteredTest extends \PHPUnit\Framework\TestCase
 {
     function test_collection_can_be_created_statically_with_children()
     {
-        $children_1 = Typed::by('a')->bar();
-        $children_2 = Typed::by('b')->baz()->bat();
+        $children_1 = Filtered::by('bar')->bar();
+        $children_2 = Filtered::by('bat')->baz()->bat();
         $coll = Collection::foo($children_1, $children_2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
@@ -15,8 +17,8 @@ class TypedTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals('a', $children_1->getExtra('type'));
-        $this->assertEquals('b', $children_2->getExtra('type'));
+        $this->assertEquals(array('bar'), $children_1->getExtra('filters'));
+        $this->assertEquals(array('bat'), $children_2->getExtra('filters'));
     }
    
 }

--- a/tests/Collections/MixedTest.php
+++ b/tests/Collections/MixedTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
-class FilteredTest extends \PHPUnit\Framework\TestCase
+class MixedTest extends \PHPUnit\Framework\TestCase
 {
     function test_collection_can_be_created_statically_with_children()
     {
-        $children_1 = Filtered::by('bar')->bar();
-        $children_2 = Filtered::by('bat')->baz()->bat();
+        $children_1 = Mix::with(array('foo' => array('bar')))->bar();
+        $children_2 = Mix::with(array('bat' => array('bar')))->baz()->bat();
         $coll = Collection::foo($children_1, $children_2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
@@ -15,8 +17,8 @@ class FilteredTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(array('bar'), $children_1->getExtra('filters'));
-        $this->assertEquals(array('bat'), $children_2->getExtra('filters'));
+        $this->assertEquals(array('foo' => array('bar')), $children_1->getExtra('mixins'));
+        $this->assertEquals(array('bat' => array('bar')), $children_2->getExtra('mixins'));
     }
    
 }

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Respect\Data\Collections;
 
-class MixedTest extends \PHPUnit\Framework\TestCase
+class TypedTest extends \PHPUnit\Framework\TestCase
 {
     function test_collection_can_be_created_statically_with_children()
     {
-        $children_1 = Mix::with(array('foo' => array('bar')))->bar();
-        $children_2 = Mix::with(array('bat' => array('bar')))->baz()->bat();
+        $children_1 = Typed::by('a')->bar();
+        $children_2 = Typed::by('b')->baz()->bat();
         $coll = Collection::foo($children_1, $children_2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
@@ -15,8 +17,8 @@ class MixedTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(array('foo' => array('bar')), $children_1->getExtra('mixins'));
-        $this->assertEquals(array('bat' => array('bar')), $children_2->getExtra('mixins'));
+        $this->assertEquals('a', $children_1->getExtra('type'));
+        $this->assertEquals('b', $children_2->getExtra('type'));
     }
    
 }


### PR DESCRIPTION
- Move source from library/Respect/Data/ to src/ and tests from tests/library/Respect/Data/ to tests/. Update PSR-4 autoload to Respect\Data\ -> src/ with autoload-dev for tests.
- Add declare(strict_types=1) to all 22 PHP files.
- Raise PHPStan to level 2 with ignores for magic method and property access patterns.
- Modernize CI: split into tests and static-analysis jobs, update to actions/checkout@v6 and ramsey/composer-install@v3.