### PR TITLE
Add type declarations, final classes, and modern PHP patterns

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 5
   paths:
     - src/
     - tests/
@@ -7,3 +7,6 @@ parameters:
     - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|Collections\\(Collection|Filtered|Mix|Typed))::\w+\(\)\./'
     - message: '/Access to an undefined property Respect\\Data\\Collections\\Collection::\$\w+\./'
     - message: '/Unsafe usage of new static\(\)\./'
+    -
+      message: '/Expression .+ on a separate line does not do anything\./'
+      path: tests/

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -9,16 +9,17 @@ use SplObjectStorage;
 
 abstract class AbstractMapper
 {
-    protected $style;
-    protected $new;
-    protected $tracked;
-    protected $changed;
-    protected $removed;
-    protected $collections = array();
+    protected ?Styles\Stylable $style = null;
+    protected SplObjectStorage $new;
+    protected SplObjectStorage $tracked;
+    protected SplObjectStorage $changed;
+    protected SplObjectStorage $removed;
+    /** @var array<string, Collection> */
+    protected array $collections = [];
 
-    abstract protected function createStatement(Collection $fromCollection, $withExtra = null);
+    abstract protected function createStatement(Collection $fromCollection, mixed $withExtra = null): mixed;
 
-    protected function parseHydrated(SplObjectStorage $hydrated)
+    protected function parseHydrated(SplObjectStorage $hydrated): mixed
     {
         $this->tracked->addAll($hydrated);
         $hydrated->rewind();
@@ -26,7 +27,7 @@ abstract class AbstractMapper
         return $hydrated->current();
     }
 
-    public function getStyle()
+    public function getStyle(): Styles\Stylable
     {
         if (null === $this->style) {
             $this->setStyle(new Styles\Standard());
@@ -35,7 +36,7 @@ abstract class AbstractMapper
         return $this->style;
     }
 
-    public function setStyle(Styles\Stylable $style)
+    public function setStyle(Styles\Stylable $style): static
     {
         $this->style = $style;
 
@@ -50,23 +51,23 @@ abstract class AbstractMapper
         $this->new      = new SplObjectStorage();
     }
 
-    abstract public function flush();
+    abstract public function flush(): void;
 
-    public function reset()
+    public function reset(): void
     {
         $this->changed = new SplObjectStorage();
         $this->removed = new SplObjectStorage();
         $this->new = new SplObjectStorage();
     }
 
-    public function markTracked($entity, Collection $collection)
+    public function markTracked(object $entity, Collection $collection): bool
     {
         $this->tracked[$entity] = $collection;
 
         return true;
     }
 
-    public function fetch(Collection $fromCollection, $withExtra = null)
+    public function fetch(Collection $fromCollection, mixed $withExtra = null): mixed
     {
         $statement = $this->createStatement($fromCollection, $withExtra);
         $hydrated = $this->fetchHydrated($fromCollection, $statement);
@@ -77,10 +78,10 @@ abstract class AbstractMapper
         return $this->parseHydrated($hydrated);
     }
 
-    public function fetchAll(Collection $fromCollection, $withExtra = null)
+    public function fetchAll(Collection $fromCollection, mixed $withExtra = null): array
     {
         $statement = $this->createStatement($fromCollection, $withExtra);
-        $entities = array();
+        $entities = [];
 
         while ($hydrated = $this->fetchHydrated($fromCollection, $statement)) {
             $entities[] = $this->parseHydrated($hydrated);
@@ -89,7 +90,7 @@ abstract class AbstractMapper
         return $entities;
     }
 
-    public function persist($object, Collection $onCollection)
+    public function persist(object $object, Collection $onCollection): bool
     {
         $this->changed[$object] = true;
 
@@ -103,7 +104,7 @@ abstract class AbstractMapper
         return true;
     }
 
-    public function remove($object, Collection $fromCollection)
+    public function remove(object $object, Collection $fromCollection): bool
     {
         $this->changed[$object] = true;
         $this->removed[$object] = true;
@@ -117,12 +118,12 @@ abstract class AbstractMapper
         return true;
     }
 
-    public function isTracked($entity)
+    public function isTracked(object $entity): bool
     {
         return $this->tracked->contains($entity);
     }
 
-    protected function fetchHydrated(Collection $collection, $statement)
+    protected function fetchHydrated(Collection $collection, mixed $statement): SplObjectStorage|false
     {
         if (!$collection->hasMore()) {
             return $this->fetchSingle($collection, $statement);
@@ -131,7 +132,7 @@ abstract class AbstractMapper
         }
     }
 
-    public function __get($name)
+    public function __get(string $name): Collection
     {
         if (isset($this->collections[$name])) {
             return $this->collections[$name];
@@ -143,17 +144,17 @@ abstract class AbstractMapper
         return $coll;
     }
 
-    public function __isset($alias)
+    public function __isset(string $alias): bool
     {
         return isset($this->collections[$alias]);
     }
 
-    public function __set($alias, $collection)
+    public function __set(string $alias, mixed $collection): void
     {
-        return $this->registerCollection($alias, $collection);
+        $this->registerCollection($alias, $collection);
     }
 
-    public function __call($name, $children)
+    public function __call(string $name, array $children): Collection
     {
         $collection = Collection::__callstatic($name, $children);
         $collection->setMapper($this);
@@ -161,7 +162,7 @@ abstract class AbstractMapper
         return $collection;
     }
 
-    public function registerCollection($alias, Collection $collection)
+    public function registerCollection(string $alias, Collection $collection): void
     {
         $collection->setMapper($this);
         $this->collections[$alias] = $collection;

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -7,19 +7,20 @@ namespace Respect\Data;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
-class CollectionIterator extends RecursiveArrayIterator
+final class CollectionIterator extends RecursiveArrayIterator
 {
-    protected $namesCounts = array();
+    /** @var array<string, int> */
+    protected array $namesCounts = [];
 
-    public static function recursive($target)
+    public static function recursive(mixed $target): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(new static($target), 1);
     }
 
-    public function __construct($target = array(), &$namesCounts = array())
+    public function __construct(mixed $target = [], array &$namesCounts = [])
     {
         $this->namesCounts = &$namesCounts;
-        parent::__construct(is_array($target) ? $target : array($target));
+        parent::__construct(is_array($target) ? $target : [$target]);
     }
 
     public function key(): string|int|null
@@ -40,10 +41,10 @@ class CollectionIterator extends RecursiveArrayIterator
         return $this->current()->hasMore();
     }
 
-    public function getChildren(): ?RecursiveArrayIterator
+    public function getChildren(): RecursiveArrayIterator
     {
         $c = $this->current();
-        $pool = array();
+        $pool = [];
 
         if ($c->hasChildren()) {
             $pool = $c->getChildren();

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -9,58 +9,62 @@ use ArrayAccess;
 
 class Collection implements ArrayAccess
 {
-    protected $required = true;
-    protected $mapper;
-    protected $name;
-    protected $condition;
-    protected $parent;
-    protected $next;
-    protected $last;
-    protected $children = array();
-    protected $extras = array();
+    protected bool $required = true;
+    protected ?AbstractMapper $mapper = null;
+    protected ?string $name = null;
+    protected mixed $condition = [];
+    protected ?Collection $parent = null;
+    protected ?Collection $next = null;
+    protected ?Collection $last = null;
+    /** @var Collection[] */
+    protected array $children = [];
+    /** @var array<string, mixed> */
+    protected array $extras = [];
 
-    public function extra($name, $specs)
+    public function extra(string $name, mixed $specs): static
     {
         $this->extras[$name] = $specs;
 
         return $this;
     }
 
-    public function getExtra($name)
+    public function getExtra(string $name): mixed
     {
         if ($this->have($name)) {
             return $this->extras[$name];
         }
+
+        return null;
     }
 
-    public function have($name)
+    public function have(string $name): bool
     {
         return isset($this->extras[$name]);
     }
 
-    public static function using($condition)
+    public static function using(mixed $condition): static
     {
-        $collection = new self();
+        $collection = new static();
         $collection->setCondition($condition);
 
         return $collection;
     }
 
-    public static function __callStatic($name, $children)
+    public static function __callStatic(string $name, array $children): static
     {
-        $collection = new self();
+        $collection = new static();
 
         return $collection->__call($name, $children);
     }
 
-    public function __construct($name = null, $condition = array())
+    public function __construct(?string $name = null, mixed $condition = [])
     {
         $this->name = $name;
         $this->condition = $condition;
         $this->last = $this;
     }
 
-    public function __get($name)
+    public function __get(string $name): static
     {
         if (isset($this->mapper) && isset($this->mapper->$name)) {
             return $this->stack(clone $this->mapper->$name);
@@ -69,7 +73,7 @@ class Collection implements ArrayAccess
         return $this->stack(new self($name));
     }
 
-    public function __call($name, $children)
+    public function __call(string $name, array $children): static
     {
         if (!isset($this->name)) {
             $this->name = $name;
@@ -89,7 +93,7 @@ class Collection implements ArrayAccess
         return $this->stack($collection);
     }
 
-    public function addChild(Collection $child)
+    public function addChild(Collection $child): void
     {
         $clone = clone $child;
         $clone->setRequired(false);
@@ -98,7 +102,7 @@ class Collection implements ArrayAccess
         $this->children[] = $clone;
     }
 
-    public function persist($object)
+    public function persist(object $object): mixed
     {
         if (!$this->mapper) {
             throw new \RuntimeException();
@@ -107,7 +111,7 @@ class Collection implements ArrayAccess
         return $this->mapper->persist($object, $this);
     }
 
-    public function remove($object)
+    public function remove(object $object): mixed
     {
         if (!$this->mapper) {
             throw new \RuntimeException();
@@ -116,7 +120,7 @@ class Collection implements ArrayAccess
         return $this->mapper->remove($object, $this);
     }
 
-    public function fetch($extra = null)
+    public function fetch(mixed $extra = null): mixed
     {
         if (!$this->mapper) {
             throw new \RuntimeException();
@@ -125,7 +129,7 @@ class Collection implements ArrayAccess
         return $this->mapper->fetch($this, $extra);
     }
 
-    public function fetchAll($extra = null)
+    public function fetchAll(mixed $extra = null): mixed
     {
         if (!$this->mapper) {
             throw new \RuntimeException();
@@ -134,52 +138,53 @@ class Collection implements ArrayAccess
         return $this->mapper->fetchAll($this, $extra);
     }
 
-    public function getChildren()
+    /** @return Collection[] */
+    public function getChildren(): array
     {
         return $this->children;
     }
 
-    public function getCondition()
+    public function getCondition(): mixed
     {
         return $this->condition;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getNext()
+    public function getNext(): ?Collection
     {
         return $this->next;
     }
 
-    public function getParentName()
+    public function getParentName(): ?string
     {
         return $this->parent ? $this->parent->getName() : null;
     }
 
-    public function getNextName()
+    public function getNextName(): ?string
     {
         return $this->next ? $this->next->getName() : null;
     }
 
-    public function hasChildren()
+    public function hasChildren(): bool
     {
-        return!empty($this->children);
+        return !empty($this->children);
     }
 
-    public function hasMore()
+    public function hasMore(): bool
     {
         return $this->hasChildren() || $this->hasNext();
     }
 
-    public function hasNext()
+    public function hasNext(): bool
     {
-        return!is_null($this->next);
+        return !is_null($this->next);
     }
 
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->required;
     }
@@ -206,7 +211,7 @@ class Collection implements ArrayAccess
         // no-op
     }
 
-    public function setCondition($condition)
+    public function setCondition(mixed $condition): void
     {
         $this->condition = $condition;
     }
@@ -219,24 +224,24 @@ class Collection implements ArrayAccess
         $this->mapper = $mapper;
     }
 
-    public function setParent(Collection $parent)
+    public function setParent(Collection $parent): void
     {
         $this->parent = $parent;
     }
 
-    public function setNext(Collection $collection)
+    public function setNext(Collection $collection): void
     {
         $collection->setParent($this);
         $collection->setMapper($this->mapper);
         $this->next = $collection;
     }
 
-    public function setRequired($required)
+    public function setRequired(bool $required): void
     {
         $this->required = $required;
     }
 
-    public function stack(Collection $collection)
+    public function stack(Collection $collection): static
     {
         $this->last->setNext($collection);
         $this->last = $collection;

--- a/src/Collections/Filterable.php
+++ b/src/Collections/Filterable.php
@@ -6,6 +6,6 @@ namespace Respect\Data\Collections;
 
 interface Filterable
 {
-    public function getFilters(Collection $collection);
-    public function filterable(Collection $collection);
+    public function getFilters(Collection $collection): mixed;
+    public function filterable(Collection $collection): mixed;
 }

--- a/src/Collections/Filtered.php
+++ b/src/Collections/Filtered.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class Filtered extends Collection
+final class Filtered extends Collection
 {
-    public static function __callStatic($name, $children)
+    public static function __callStatic(string $name, array $children): static
     {
-        $collection = new self();
-        $collection->extra('filters', array());
+        $collection = new static();
+        $collection->extra('filters', []);
 
         return $collection->__call($name, $children);
     }
 
-    public static function by($name)
+    public static function by(string $name): Collection
     {
         $collection = new Collection();
         $collection->extra('filters', func_get_args());

--- a/src/Collections/Mix.php
+++ b/src/Collections/Mix.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class Mix extends Collection
+final class Mix extends Collection
 {
-    public static function __callStatic($name, $children)
+    public static function __callStatic(string $name, array $children): static
     {
-        $collection = new self();
-        $collection->extra('mixins', array());
+        $collection = new static();
+        $collection->extra('mixins', []);
 
         return $collection->__call($name, $children);
     }
 
-    public static function with($mixins)
+    public static function with(mixed $mixins): Collection
     {
         $collection = new Collection();
         $collection->extra('mixins', $mixins);

--- a/src/Collections/Mixable.php
+++ b/src/Collections/Mixable.php
@@ -6,6 +6,6 @@ namespace Respect\Data\Collections;
 
 interface Mixable
 {
-    public function getMixins(Collection $collection);
-    public function mixable(Collection $collection);
+    public function getMixins(Collection $collection): mixed;
+    public function mixable(Collection $collection): mixed;
 }

--- a/src/Collections/Typable.php
+++ b/src/Collections/Typable.php
@@ -6,6 +6,6 @@ namespace Respect\Data\Collections;
 
 interface Typable
 {
-    public function getType(Collection $collection);
-    public function typable(Collection $collection);
+    public function getType(Collection $collection): mixed;
+    public function typable(Collection $collection): mixed;
 }

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class Typed extends Collection
+final class Typed extends Collection
 {
-    public static function __callStatic($name, $children)
+    public static function __callStatic(string $name, array $children): static
     {
-        $collection = new self();
+        $collection = new static();
         $collection->extra('type', '');
 
         return $collection->__call($name, $children);
     }
 
-    public static function by($type)
+    public static function by(string $type): Collection
     {
         $collection = new Collection();
         $collection->extra('type', $type);

--- a/src/Styles/AbstractStyle.php
+++ b/src/Styles/AbstractStyle.php
@@ -6,28 +6,28 @@ namespace Respect\Data\Styles;
 
 abstract class AbstractStyle implements Stylable
 {
-    protected function camelCaseToSeparator($name, $separator = '_')
+    protected function camelCaseToSeparator(string $name, string $separator = '_'): string
     {
         return preg_replace('/(?<=[a-z])([A-Z])/', $separator.'$1', $name);
     }
 
-    protected function separatorToCamelCase($name, $separator = '_')
+    protected function separatorToCamelCase(string $name, string $separator = '_'): string
     {
         $separator = preg_quote($separator, '/');
 
         return preg_replace_callback(
             "/{$separator}([a-zA-Z])/",
-            function ($m) { return strtoupper($m[1]); },
+            fn($m) => strtoupper($m[1]),
             $name
         );
     }
 
-    protected function pluralToSingular($name)
+    protected function pluralToSingular(string $name): string
     {
-        $replacements = array(
+        $replacements = [
             '/^(.+)ies$/' => '$1y',
             '/^(.+)s$/' => '$1',
-        );
+        ];
         foreach ($replacements as $key => $value) {
             if (preg_match($key, $name)) {
                 return preg_replace($key, $value, $name);
@@ -37,12 +37,12 @@ abstract class AbstractStyle implements Stylable
         return $name;
     }
 
-    protected function singularToPlural($name)
+    protected function singularToPlural(string $name): string
     {
-        $replacements = array(
+        $replacements = [
             '/^(.+)y$/' => '$1ies',
             '/^(.+)([^s])$/' => '$1$2s',
-        );
+        ];
         foreach ($replacements as $key => $value) {
             if (preg_match($key, $name)) {
                 return preg_replace($key, $value, $name);

--- a/src/Styles/CakePHP.php
+++ b/src/Styles/CakePHP.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
-class CakePHP extends Standard
+final class CakePHP extends Standard
 {
-    public function realName($name)
+    public function realName(string $name): string
     {
         $name       = $this->camelCaseToSeparator($name, '_');
         $name       = strtolower($name);
@@ -16,19 +16,21 @@ class CakePHP extends Standard
         return implode('_', $pieces);
     }
 
-    public function remoteIdentifier($name)
+    public function remoteIdentifier(string $name): string
     {
         return $this->pluralToSingular($name).'_id';
     }
 
-    public function remoteFromIdentifier($name)
+    public function remoteFromIdentifier(string $name): ?string
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -3));
         }
+
+        return null;
     }
 
-    public function styledName($name)
+    public function styledName(string $name): string
     {
         $pieces     = explode('_', $name);
         $pieces[]   = $this->pluralToSingular(array_pop($pieces));
@@ -37,7 +39,7 @@ class CakePHP extends Standard
         return ucfirst($name);
     }
 
-    public function composed($left, $right)
+    public function composed(string $left, string $right): string
     {
         $pieces     = explode('_', $right);
         $pieces[]   = $this->singularToPlural(array_pop($pieces));

--- a/src/Styles/NorthWind.php
+++ b/src/Styles/NorthWind.php
@@ -4,44 +4,46 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
-class NorthWind extends Standard
+final class NorthWind extends Standard
 {
-    public function realName($name)
+    public function realName(string $name): string
     {
         return $name;
     }
 
-    public function styledName($name)
+    public function styledName(string $name): string
     {
         return $name;
     }
 
-    public function composed($left, $right)
+    public function composed(string $left, string $right): string
     {
         $left = $this->pluralToSingular($left);
 
         return "{$left}{$right}";
     }
 
-    public function identifier($name)
+    public function identifier(string $name): string
     {
         return $this->pluralToSingular($name).'ID';
     }
 
-    public function remoteIdentifier($name)
+    public function remoteIdentifier(string $name): string
     {
         return $this->pluralToSingular($name).'ID';
     }
 
-    public function isRemoteIdentifier($name)
+    public function isRemoteIdentifier(string $name): bool
     {
         return (strlen($name) - 2 === strripos($name, 'ID'));
     }
 
-    public function remoteFromIdentifier($name)
+    public function remoteFromIdentifier(string $name): ?string
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -2));
         }
+
+        return null;
     }
 }

--- a/src/Styles/Plural.php
+++ b/src/Styles/Plural.php
@@ -15,37 +15,39 @@ namespace Respect\Data\Styles;
  *            title                     category_id
  *
  */
-class Plural extends Standard
+final class Plural extends Standard
 {
-    public function remoteIdentifier($name)
+    public function remoteIdentifier(string $name): string
     {
         return $this->pluralToSingular($name).'_id';
     }
 
-    public function remoteFromIdentifier($name)
+    public function remoteFromIdentifier(string $name): ?string
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -3));
         }
+
+        return null;
     }
 
-    public function realName($name)
+    public function realName(string $name): string
     {
         $name    = strtolower($this->camelCaseToSeparator($name, '_'));
-        $pieces  = array_map(array($this, 'singularToPlural'), explode('_', $name));
+        $pieces  = array_map($this->singularToPlural(...), explode('_', $name));
 
         return implode('_', $pieces);
     }
 
-    public function styledName($name)
+    public function styledName(string $name): string
     {
-        $pieces  = array_map(array($this, 'pluralToSingular'), explode('_', $name));
+        $pieces  = array_map($this->pluralToSingular(...), explode('_', $name));
         $name    = $this->separatorToCamelCase(implode('_', $pieces), '_');
 
         return ucfirst($name);
     }
 
-    public function composed($left, $right)
+    public function composed(string $left, string $right): string
     {
         $left  = $this->singularToPlural($left);
         $right = $this->singularToPlural($right);

--- a/src/Styles/Sakila.php
+++ b/src/Styles/Sakila.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
-class Sakila extends Standard
+final class Sakila extends Standard
 {
-    public function identifier($name)
+    public function identifier(string $name): string
     {
         return $this->remoteIdentifier($name);
     }

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -6,54 +6,56 @@ namespace Respect\Data\Styles;
 
 class Standard extends AbstractStyle
 {
-    public function styledProperty($name)
+    public function styledProperty(string $name): string
     {
         return $name;
     }
 
-    public function realName($name)
+    public function realName(string $name): string
     {
         $name = $this->camelCaseToSeparator($name, '_');
 
         return strtolower($name);
     }
 
-    public function realProperty($name)
+    public function realProperty(string $name): string
     {
         return $name;
     }
 
-    public function styledName($name)
+    public function styledName(string $name): string
     {
         $name = $this->separatorToCamelCase($name, '_');
 
         return ucfirst($name);
     }
 
-    public function identifier($name)
+    public function identifier(string $name): string
     {
         return 'id';
     }
 
-    public function remoteIdentifier($name)
+    public function remoteIdentifier(string $name): string
     {
         return $name.'_id';
     }
 
-    public function composed($left, $right)
+    public function composed(string $left, string $right): string
     {
         return "{$left}_{$right}";
     }
 
-    public function isRemoteIdentifier($name)
+    public function isRemoteIdentifier(string $name): bool
     {
         return (strlen($name) - 3 === strripos($name, '_id'));
     }
 
-    public function remoteFromIdentifier($name)
+    public function remoteFromIdentifier(string $name): ?string
     {
         if ($this->isRemoteIdentifier($name)) {
             return substr($name, 0, -3);
         }
+
+        return null;
     }
 }

--- a/src/Styles/Stylable.php
+++ b/src/Styles/Stylable.php
@@ -6,21 +6,21 @@ namespace Respect\Data\Styles;
 
 interface Stylable
 {
-    public function styledName($entityName);
+    public function styledName(string $entityName): string;
 
-    public function realName($styledName);
+    public function realName(string $styledName): string;
 
-    public function styledProperty($name);
+    public function styledProperty(string $name): string;
 
-    public function realProperty($name);
+    public function realProperty(string $name): string;
 
-    public function identifier($name);
+    public function identifier(string $name): string;
 
-    public function remoteIdentifier($name);
+    public function remoteIdentifier(string $name): string;
 
-    public function remoteFromIdentifier($name);
+    public function remoteFromIdentifier(string $name): ?string;
 
-    public function isRemoteIdentifier($name);
+    public function isRemoteIdentifier(string $name): bool;
 
-    public function composed($left, $right);
+    public function composed(string $left, string $right): string;
 }

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -145,13 +145,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     function test_persist_should_persist_on_attached_mapper()
     {
         $persisted = new \stdClass();
-        $result = 'result stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
         $mapperMock->expects($this->once())
                    ->method('persist')
                    ->with($persisted, $collection)
-                   ->willReturn($result);
+                   ->willReturn(true);
         $collection->setMapper($mapperMock);
         $collection->persist($persisted);
     }
@@ -159,13 +158,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     function test_remove_should_persist_on_attached_mapper()
     {
         $removed = new \stdClass();
-        $result = 'result stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
         $mapperMock->expects($this->once())
                    ->method('remove')
                    ->with($removed, $collection)
-                   ->willReturn($result);
+                   ->willReturn(true);
         $collection->setMapper($mapperMock);
         $collection->remove($removed);
     }
@@ -198,27 +196,25 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     }
     function test_fetchAll_should_persist_on_attached_mapper()
     {
-        $result = 'result stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
         $mapperMock->expects($this->once())
                    ->method('fetchAll')
                    ->with($collection)
-                   ->willReturn($result);
+                   ->willReturn([]);
         $collection->setMapper($mapperMock);
         $collection->fetchAll();
     }
 
     function test_fetchAll_should_persist_on_attached_mapper_with_extra_param()
     {
-        $result = 'result stub';
         $extra = 'extra stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
         $mapperMock->expects($this->once())
                    ->method('fetchAll')
                    ->with($collection, $extra)
-                   ->willReturn($result);
+                   ->willReturn([]);
         $collection->setMapper($mapperMock);
         $collection->fetchAll($extra);
     }


### PR DESCRIPTION
Type declarations:
- Add typed properties to all classes (SplObjectStorage, array, ?string, mixed, bool, ?AbstractMapper, ?Collection)
- Add return types to all methods (static, void, bool, mixed, string, ?string, array, RecursiveIteratorIterator)
- Add parameter types throughout all interfaces and implementations
- Replace array() with [] and new self() with new static()
- Fix test mocks to return correct types

Modern patterns:
- Mark leaf classes final: CollectionIterator, Filtered, Mix, Typed, CakePHP, NorthWind, Plural, Sakila
- Use arrow function in AbstractStyle::separatorToCamelCase
- Remove unnecessary nullable from CollectionIterator::getChildren

Raise PHPStan to level 5.