### PR TITLE
Upgrade PHPUnit to ^12.5, modernize all tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^12.5",
         "respect/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^4.0"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ parameters:
     - tests/
   ignoreErrors:
     - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|Collections\\(Collection|Filtered|Mix|Typed))::\w+\(\)\./'
-    - message: '/Access to an undefined property Respect\\Data\\Collections\\Collection::\$\w+\./'
+    - message: '/Access to an undefined property Respect\\Data\\(AbstractMapper|Collections\\Collection)::\$\w+\./'
     - message: '/Unsafe usage of new static\(\)\./'
     -
       message: '/Expression .+ on a separate line does not do anything\./'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,15 @@
-<phpunit bootstrap="vendor/autoload.php" colors="false" stopOnFailure="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnPhpunitDeprecations="true" failOnDeprecation="false">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
     <testsuites>
-        <testsuite name="Default">
+        <testsuite name="unit">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -120,7 +120,7 @@ abstract class AbstractMapper
 
     public function isTracked(object $entity): bool
     {
-        return $this->tracked->contains($entity);
+        return $this->tracked->offsetExists($entity);
     }
 
     protected function fetchHydrated(Collection $collection, mixed $statement): SplObjectStorage|false

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -4,19 +4,32 @@ declare(strict_types=1);
 
 namespace Respect\Data;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use Respect\Data\Collections\Collection;
 
-class AbstractMapperTest extends \PHPUnit\Framework\TestCase
+#[CoversClass(AbstractMapper::class)]
+class AbstractMapperTest extends TestCase
 {
-    protected $mapper;
+    protected AbstractMapper $mapper;
 
     protected function setUp(): void
     {
-        parent::setUp();
-        $this->mapper = $this->getMockForAbstractClass('Respect\Data\AbstractMapper');
+        $this->mapper = new class extends AbstractMapper {
+            protected function createStatement(Collection $fromCollection, mixed $withExtra = null): mixed
+            {
+                return null;
+            }
+
+            public function flush(): void
+            {
+            }
+        };
     }
 
-    function test_registerCollection_should_add_collection_to_pool()
+    #[Test]
+    public function registerCollection_should_add_collection_to_pool(): void
     {
         $coll = Collection::foo();
         $this->mapper->registerCollection('my_alias', $coll);
@@ -28,7 +41,8 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($coll, $this->mapper->my_alias);
     }
 
-    function test_magic_setter_should_add_collection_to_pool()
+    #[Test]
+    public function magic_setter_should_add_collection_to_pool(): void
     {
         $coll = Collection::foo();
         $this->mapper->my_alias = $coll;
@@ -40,14 +54,17 @@ class AbstractMapperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($coll, $this->mapper->my_alias);
     }
 
-    function test_magic_call_should_bypass_to_collection()
+    #[Test]
+    public function magic_call_should_bypass_to_collection(): void
     {
         $collection = $this->mapper->foo()->bar()->baz();
         $expected = Collection::foo();
         $expected->setMapper($this->mapper);
         $this->assertEquals($expected->bar->baz, $collection);
     }
-    function test_magic_getter_should_bypass_to_collection()
+
+    #[Test]
+    public function magic_getter_should_bypass_to_collection(): void
     {
         $collection = $this->mapper->foo->bar->baz;
         $expected = Collection::foo();

--- a/tests/CollectionIteratorTest.php
+++ b/tests/CollectionIteratorTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Respect\Data;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use Respect\Data\Collections\Collection;
 
-class CollectionIteratorTest extends \PHPUnit\Framework\TestCase
+#[CoversClass(CollectionIterator::class)]
+class CollectionIteratorTest extends TestCase
 {
-    function test_static_builder_should_create_recursive_iterator()
+    #[Test]
+    public function static_builder_should_create_recursive_iterator(): void
     {
         $this->assertInstanceOf(
             'RecursiveIteratorIterator',
@@ -16,14 +21,16 @@ class CollectionIteratorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    function test_constructing_should_accept_collections_or_arrays()
+    #[Test]
+    public function constructing_should_accept_collections_or_arrays(): void
     {
         $iterator = new CollectionIterator(Collection::foo());
         $iterator2 = new CollectionIterator(array(Collection::foo()));
         $this->assertEquals($iterator, $iterator2);
     }
 
-    function test_key_should_track_nameCounts()
+    #[Test]
+    public function key_should_track_nameCounts(): void
     {
         $i = new CollectionIterator(Collection::foo());
         $this->assertEquals('foo', $i->key());
@@ -31,35 +38,40 @@ class CollectionIteratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo3', $i->key());
     }
 
-    function test_hasChildren_consider_empties()
+    #[Test]
+    public function hasChildren_consider_empties(): void
     {
         $coll = Collection::foo();
         $iterator = new CollectionIterator($coll);
         $this->assertFalse($iterator->hasChildren());
     }
 
-    function test_hasChildren_use_collection_children()
+    #[Test]
+    public function hasChildren_use_collection_children(): void
     {
         $coll = Collection::foo(Collection::bar());
         $iterator = new CollectionIterator($coll);
         $this->assertTrue($iterator->hasChildren());
     }
 
-    function test_hasChildren_use_collection_next()
+    #[Test]
+    public function hasChildren_use_collection_next(): void
     {
         $coll = Collection::foo()->bar;
         $iterator = new CollectionIterator($coll);
         $this->assertTrue($iterator->hasChildren());
     }
 
-    function test_getChildren_consider_empties()
+    #[Test]
+    public function getChildren_consider_empties(): void
     {
         $coll = Collection::foo();
         $iterator = new CollectionIterator($coll);
         $this->assertEquals(new CollectionIterator(), $iterator->getChildren());
     }
 
-    function test_getChildren_use_collection_children()
+    #[Test]
+    public function getChildren_use_collection_children(): void
     {
         $coll = Collection::foo(Collection::bar(), Collection::baz());
         list($foo_child, $bar_child) = $coll->getChildren();
@@ -68,11 +80,11 @@ class CollectionIteratorTest extends \PHPUnit\Framework\TestCase
         $this->assertContains($bar_child, $items);
     }
 
-    function test_getChildren_use_collection_next()
+    #[Test]
+    public function getChildren_use_collection_next(): void
     {
         $coll = Collection::foo()->bar;
         $iterator = new CollectionIterator($coll);
         $this->assertTrue($iterator->hasChildren());
     }
-
 }

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class CollectionTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Respect\Data\AbstractMapper;
+
+#[CoversClass(Collection::class)]
+class CollectionTest extends TestCase
 {
-    function test_collection_can_be_created_statically_with_just_a_name()
+    #[Test]
+    public function collection_can_be_created_statically_with_just_a_name(): void
     {
         $coll = Collection::fooBarName();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
     }
 
-    function test_collection_can_be_created_statically_with_children()
+    #[Test]
+    public function collection_can_be_created_statically_with_children(): void
     {
         $children_1 = Collection::bar();
         $children_2 = Collection::baz();
@@ -22,14 +30,16 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(2, count($coll->getChildren()));
     }
 
-    function test_collection_can_be_created_statically_with_condition()
+    #[Test]
+    public function collection_can_be_created_statically_with_condition(): void
     {
         $coll = Collection::fooBar(42);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertEquals(42, $coll->getCondition());
     }
 
-    function test_multiple_conditions_on_static_creation_leaves_the_last()
+    #[Test]
+    public function multiple_conditions_on_static_creation_leaves_the_last(): void
     {
         $coll = Collection::fooBar(42, 'Other dominant condition!!!');
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
@@ -38,7 +48,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    function test_object_constructor_should_set_object_attributes()
+    #[Test]
+    public function object_constructor_should_set_object_attributes(): void
     {
         $coll = new Collection('some_irrelevant_name');
         $ref = new \ReflectionObject($coll);
@@ -51,13 +62,15 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('some_irrelevant_name', $coll->getName());
     }
 
-    function test_object_constructor_with_condition_should_set_it()
+    #[Test]
+    public function object_constructor_with_condition_should_set_it(): void
     {
         $coll = new Collection('some_irrelevant_name', 123);
         $this->assertEquals(123, $coll->getCondition());
     }
 
-    function test_dynamic_getter_should_stack_collection()
+    #[Test]
+    public function dynamic_getter_should_stack_collection(): void
     {
         $coll = new Collection('hi');
         $coll->some_test;
@@ -67,7 +80,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    function test_dynamic_getter_should_chain_collection()
+    #[Test]
+    public function dynamic_getter_should_chain_collection(): void
     {
         $coll = new Collection('hi');
         $coll->some_test;
@@ -82,7 +96,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    function test_setting_condition_via_dynamic_offset_should_use_last_node()
+    #[Test]
+    public function setting_condition_via_dynamic_offset_should_use_last_node(): void
     {
         $foo = Collection::foo()->bar->baz[42];
         $bar = $foo->getNext();
@@ -92,7 +107,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(42, $baz->getCondition());
     }
 
-    function test_dynamic_method_call_should_accept_children()
+    #[Test]
+    public function dynamic_method_call_should_accept_children(): void
     {
         $coll = new Collection('some_name');
         $coll->foo_bar(
@@ -103,7 +119,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, count($coll->getNext()->getChildren()));
     }
 
-    function test_addChild_should_set_children_object_properties()
+    #[Test]
+    public function addChild_should_set_children_object_properties(): void
     {
         $coll = new Collection('foo_collection');
         $coll->addChild(new Collection('bar_child'));
@@ -113,19 +130,22 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($coll->getName(), $child->getParentName());
     }
 
-    function test_children_should_make_hasMore_true()
+    #[Test]
+    public function children_should_make_hasMore_true(): void
     {
         $coll = Collection::foo(Collection::this_is_a_children());
         $this->assertTrue($coll->hasMore());
     }
 
-    function test_chaining_should_make_hasMore_true()
+    #[Test]
+    public function chaining_should_make_hasMore_true(): void
     {
         $coll = Collection::foo()->barChain;
         $this->assertTrue($coll->hasMore());
     }
 
-    function test_array_offsetSet_should_NOT_do_anything()
+    #[Test]
+    public function array_offsetSet_should_NOT_do_anything(): void
     {
         $touched = Collection::foo()->bar;
         $touched['magic'] = 'FOOOO';
@@ -133,7 +153,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($untouched, $touched);
     }
 
-    function test_array_offsetUnset_should_NOT_do_anything()
+    #[Test]
+    public function array_offsetUnset_should_NOT_do_anything(): void
     {
         $touched = Collection::foo()->bar;
         unset($touched['magic']);
@@ -142,11 +163,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($untouched, $touched);
     }
 
-    function test_persist_should_persist_on_attached_mapper()
+    #[Test]
+    public function persist_should_persist_on_attached_mapper(): void
     {
         $persisted = new \stdClass();
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('persist')
                    ->with($persisted, $collection)
@@ -155,11 +177,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->persist($persisted);
     }
 
-    function test_remove_should_persist_on_attached_mapper()
+    #[Test]
+    public function remove_should_persist_on_attached_mapper(): void
     {
         $removed = new \stdClass();
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('remove')
                    ->with($removed, $collection)
@@ -168,11 +191,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->remove($removed);
     }
 
-    function test_fetch_should_persist_on_attached_mapper()
+    #[Test]
+    public function fetch_should_persist_on_attached_mapper(): void
     {
         $result = 'result stub';
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('fetch')
                    ->with($collection)
@@ -181,12 +205,13 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->fetch();
     }
 
-    function test_fetch_should_persist_on_attached_mapper_with_extra_param()
+    #[Test]
+    public function fetch_should_persist_on_attached_mapper_with_extra_param(): void
     {
         $result = 'result stub';
         $extra = 'extra stub';
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('fetch')
                    ->with($collection, $extra)
@@ -194,10 +219,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->setMapper($mapperMock);
         $collection->fetch($extra);
     }
-    function test_fetchAll_should_persist_on_attached_mapper()
+
+    #[Test]
+    public function fetchAll_should_persist_on_attached_mapper(): void
     {
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('fetchAll')
                    ->with($collection)
@@ -206,11 +233,12 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->fetchAll();
     }
 
-    function test_fetchAll_should_persist_on_attached_mapper_with_extra_param()
+    #[Test]
+    public function fetchAll_should_persist_on_attached_mapper_with_extra_param(): void
     {
         $extra = 'extra stub';
         $collection = new Collection('name_whatever');
-        $mapperMock = $this->createMock('Respect\\Data\\AbstractMapper');
+        $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
                    ->method('fetchAll')
                    ->with($collection, $extra)
@@ -219,7 +247,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $collection->fetchAll($extra);
     }
 
-    function test_array_offsetExists_should_NOT_do_anything()
+    #[Test]
+    public function array_offsetExists_should_NOT_do_anything(): void
     {
         $touched = Collection::foo()->bar;
         $this->assertFalse(isset($touched['magic']));
@@ -227,30 +256,31 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($untouched, $touched);
     }
 
-    function test_persist_on_collection_should_exception_if_mapper_dont_exist()
+    #[Test]
+    public function persist_on_collection_should_exception_if_mapper_dont_exist(): void
     {
         $this->expectException(\RuntimeException::class);
         Collection::foo()->persist(new \stdClass);
     }
 
-    function test_remove_on_collection_should_exception_if_mapper_dont_exist()
+    #[Test]
+    public function remove_on_collection_should_exception_if_mapper_dont_exist(): void
     {
         $this->expectException(\RuntimeException::class);
         Collection::foo()->remove(new \stdClass);
     }
 
-    function test_fetch_on_collection_should_exception_if_mapper_dont_exist()
+    #[Test]
+    public function fetch_on_collection_should_exception_if_mapper_dont_exist(): void
     {
         $this->expectException(\RuntimeException::class);
         Collection::foo()->fetch();
     }
 
-    function test_fetchAll_on_collection_should_exception_if_mapper_dont_exist()
+    #[Test]
+    public function fetchAll_on_collection_should_exception_if_mapper_dont_exist(): void
     {
         $this->expectException(\RuntimeException::class);
         Collection::foo()->fetchAll();
     }
-
-
-    
 }

--- a/tests/Collections/FilteredTest.php
+++ b/tests/Collections/FilteredTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class FilteredTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Filtered::class)]
+class FilteredTest extends TestCase
 {
-    function test_collection_can_be_created_statically_with_children()
+    #[Test]
+    public function collection_can_be_created_statically_with_children(): void
     {
         $children_1 = Filtered::by('bar')->bar();
         $children_2 = Filtered::by('bat')->baz()->bat();
@@ -20,5 +26,4 @@ class FilteredTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array('bar'), $children_1->getExtra('filters'));
         $this->assertEquals(array('bat'), $children_2->getExtra('filters'));
     }
-   
 }

--- a/tests/Collections/MixedTest.php
+++ b/tests/Collections/MixedTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class MixedTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Mix::class)]
+class MixedTest extends TestCase
 {
-    function test_collection_can_be_created_statically_with_children()
+    #[Test]
+    public function collection_can_be_created_statically_with_children(): void
     {
         $children_1 = Mix::with(array('foo' => array('bar')))->bar();
         $children_2 = Mix::with(array('bat' => array('bar')))->baz()->bat();
@@ -20,5 +26,4 @@ class MixedTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array('foo' => array('bar')), $children_1->getExtra('mixins'));
         $this->assertEquals(array('bat' => array('bar')), $children_2->getExtra('mixins'));
     }
-   
 }

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-class TypedTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Typed::class)]
+class TypedTest extends TestCase
 {
-    function test_collection_can_be_created_statically_with_children()
+    #[Test]
+    public function collection_can_be_created_statically_with_children(): void
     {
         $children_1 = Typed::by('a')->bar();
         $children_2 = Typed::by('b')->baz()->bat();
@@ -20,5 +26,4 @@ class TypedTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('a', $children_1->getExtra('type'));
         $this->assertEquals('b', $children_2->getExtra('type'));
     }
-   
 }


### PR DESCRIPTION
- Upgrade phpunit/phpunit from ^10.0 to ^12.5
- Update phpunit.xml.dist to PHPUnit 12 schema
- Replace getMockForAbstractClass() with concrete anonymous subclass in AbstractMapperTest (getMockForAbstractClass was removed in PHPUnit 12)
- Add #[CoversClass] and #[Test] attributes to all test classes
- Add public visibility and :void return type to all test methods
- Use TestCase import instead of FQCN