### PR TITLE
Apply PHPCS coding standard, fix all violations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,5 +14,7 @@
     <file>src/</file>
     <file>tests/</file>
 
-    <rule ref="Respect" />
+    <rule ref="Respect">
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix" />
+    </rule>
 </ruleset>

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -9,27 +9,30 @@ use SplObjectStorage;
 
 abstract class AbstractMapper
 {
-    protected ?Styles\Stylable $style = null;
+    protected Styles\Stylable|null $style = null;
+
     protected SplObjectStorage $new;
+
     protected SplObjectStorage $tracked;
+
     protected SplObjectStorage $changed;
+
     protected SplObjectStorage $removed;
+
     /** @var array<string, Collection> */
     protected array $collections = [];
 
-    abstract protected function createStatement(Collection $fromCollection, mixed $withExtra = null): mixed;
-
-    protected function parseHydrated(SplObjectStorage $hydrated): mixed
+    public function __construct()
     {
-        $this->tracked->addAll($hydrated);
-        $hydrated->rewind();
-
-        return $hydrated->current();
+        $this->tracked  = new SplObjectStorage();
+        $this->changed  = new SplObjectStorage();
+        $this->removed  = new SplObjectStorage();
+        $this->new      = new SplObjectStorage();
     }
 
     public function getStyle(): Styles\Stylable
     {
-        if (null === $this->style) {
+        if ($this->style === null) {
             $this->setStyle(new Styles\Standard());
         }
 
@@ -41,14 +44,6 @@ abstract class AbstractMapper
         $this->style = $style;
 
         return $this;
-    }
-
-    public function __construct()
-    {
-        $this->tracked  = new SplObjectStorage();
-        $this->changed  = new SplObjectStorage();
-        $this->removed  = new SplObjectStorage();
-        $this->new      = new SplObjectStorage();
     }
 
     abstract public function flush(): void;
@@ -78,6 +73,7 @@ abstract class AbstractMapper
         return $this->parseHydrated($hydrated);
     }
 
+    /** @return array<int, mixed> */
     public function fetchAll(Collection $fromCollection, mixed $withExtra = null): array
     {
         $statement = $this->createStatement($fromCollection, $withExtra);
@@ -123,13 +119,29 @@ abstract class AbstractMapper
         return $this->tracked->offsetExists($entity);
     }
 
+    public function registerCollection(string $alias, Collection $collection): void
+    {
+        $collection->setMapper($this);
+        $this->collections[$alias] = $collection;
+    }
+
+    abstract protected function createStatement(Collection $fromCollection, mixed $withExtra = null): mixed;
+
+    protected function parseHydrated(SplObjectStorage $hydrated): mixed
+    {
+        $this->tracked->addAll($hydrated);
+        $hydrated->rewind();
+
+        return $hydrated->current();
+    }
+
     protected function fetchHydrated(Collection $collection, mixed $statement): SplObjectStorage|false
     {
         if (!$collection->hasMore()) {
             return $this->fetchSingle($collection, $statement);
-        } else {
-            return $this->fetchMulti($collection, $statement);
         }
+
+        return $this->fetchMulti($collection, $statement);
     }
 
     public function __get(string $name): Collection
@@ -154,17 +166,12 @@ abstract class AbstractMapper
         $this->registerCollection($alias, $collection);
     }
 
+    /** @param array<int, mixed> $children */
     public function __call(string $name, array $children): Collection
     {
         $collection = Collection::__callstatic($name, $children);
         $collection->setMapper($this);
 
         return $collection;
-    }
-
-    public function registerCollection(string $alias, Collection $collection): void
-    {
-        $collection->setMapper($this);
-        $this->collections[$alias] = $collection;
     }
 }

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -7,20 +7,24 @@ namespace Respect\Data;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
+use function is_array;
+
 final class CollectionIterator extends RecursiveArrayIterator
 {
     /** @var array<string, int> */
     protected array $namesCounts = [];
 
-    public static function recursive(mixed $target): RecursiveIteratorIterator
-    {
-        return new RecursiveIteratorIterator(new static($target), 1);
-    }
-
+    /** @param array<string, int> $namesCounts */
     public function __construct(mixed $target = [], array &$namesCounts = [])
     {
         $this->namesCounts = &$namesCounts;
+
         parent::__construct(is_array($target) ? $target : [$target]);
+    }
+
+    public static function recursive(mixed $target): RecursiveIteratorIterator
+    {
+        return new RecursiveIteratorIterator(new static($target), 1);
     }
 
     public function key(): string|int|null
@@ -28,7 +32,7 @@ final class CollectionIterator extends RecursiveArrayIterator
         $name = $this->current()->getName();
 
         if (isset($this->namesCounts[$name])) {
-            return $name.++$this->namesCounts[$name];
+            return $name . ++$this->namesCounts[$name];
         }
 
         $this->namesCounts[$name] = 1;

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -4,22 +4,32 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
-use Respect\Data\AbstractMapper;
 use ArrayAccess;
+use Respect\Data\AbstractMapper;
+use RuntimeException;
 
 class Collection implements ArrayAccess
 {
     protected bool $required = true;
-    protected ?AbstractMapper $mapper = null;
-    protected ?string $name = null;
-    protected mixed $condition = [];
-    protected ?Collection $parent = null;
-    protected ?Collection $next = null;
-    protected ?Collection $last = null;
+
+    protected AbstractMapper|null $mapper = null;
+
+    protected Collection|null $parent = null;
+
+    protected Collection|null $next = null;
+
+    protected Collection|null $last = null;
+
     /** @var Collection[] */
     protected array $children = [];
+
     /** @var array<string, mixed> */
     protected array $extras = [];
+
+    public function __construct(protected string|null $name = null, protected mixed $condition = [])
+    {
+        $this->last = $this;
+    }
 
     public function extra(string $name, mixed $specs): static
     {
@@ -50,49 +60,6 @@ class Collection implements ArrayAccess
         return $collection;
     }
 
-    public static function __callStatic(string $name, array $children): static
-    {
-        $collection = new static();
-
-        return $collection->__call($name, $children);
-    }
-
-    public function __construct(?string $name = null, mixed $condition = [])
-    {
-        $this->name = $name;
-        $this->condition = $condition;
-        $this->last = $this;
-    }
-
-    public function __get(string $name): static
-    {
-        if (isset($this->mapper) && isset($this->mapper->$name)) {
-            return $this->stack(clone $this->mapper->$name);
-        }
-
-        return $this->stack(new self($name));
-    }
-
-    public function __call(string $name, array $children): static
-    {
-        if (!isset($this->name)) {
-            $this->name = $name;
-            foreach ($children as $child) {
-                if ($child instanceof Collection) {
-                    $this->addChild($child);
-                } else {
-                    $this->setCondition($child);
-                }
-            }
-
-            return $this;
-        }
-
-        $collection = self::__callStatic($name, $children);
-
-        return $this->stack($collection);
-    }
-
     public function addChild(Collection $child): void
     {
         $clone = clone $child;
@@ -105,7 +72,7 @@ class Collection implements ArrayAccess
     public function persist(object $object): mixed
     {
         if (!$this->mapper) {
-            throw new \RuntimeException();
+            throw new RuntimeException();
         }
 
         return $this->mapper->persist($object, $this);
@@ -114,7 +81,7 @@ class Collection implements ArrayAccess
     public function remove(object $object): mixed
     {
         if (!$this->mapper) {
-            throw new \RuntimeException();
+            throw new RuntimeException();
         }
 
         return $this->mapper->remove($object, $this);
@@ -123,7 +90,7 @@ class Collection implements ArrayAccess
     public function fetch(mixed $extra = null): mixed
     {
         if (!$this->mapper) {
-            throw new \RuntimeException();
+            throw new RuntimeException();
         }
 
         return $this->mapper->fetch($this, $extra);
@@ -132,7 +99,7 @@ class Collection implements ArrayAccess
     public function fetchAll(mixed $extra = null): mixed
     {
         if (!$this->mapper) {
-            throw new \RuntimeException();
+            throw new RuntimeException();
         }
 
         return $this->mapper->fetchAll($this, $extra);
@@ -149,22 +116,22 @@ class Collection implements ArrayAccess
         return $this->condition;
     }
 
-    public function getName(): ?string
+    public function getName(): string|null
     {
         return $this->name;
     }
 
-    public function getNext(): ?Collection
+    public function getNext(): Collection|null
     {
         return $this->next;
     }
 
-    public function getParentName(): ?string
+    public function getParentName(): string|null
     {
         return $this->parent ? $this->parent->getName() : null;
     }
 
-    public function getNextName(): ?string
+    public function getNextName(): string|null
     {
         return $this->next ? $this->next->getName() : null;
     }
@@ -181,7 +148,7 @@ class Collection implements ArrayAccess
 
     public function hasNext(): bool
     {
-        return !is_null($this->next);
+        return $this->next !== null;
     }
 
     public function isRequired(): bool
@@ -216,11 +183,12 @@ class Collection implements ArrayAccess
         $this->condition = $condition;
     }
 
-    public function setMapper(?AbstractMapper $mapper = null): void
+    public function setMapper(AbstractMapper|null $mapper = null): void
     {
         foreach ($this->children as $child) {
             $child->setMapper($mapper);
         }
+
         $this->mapper = $mapper;
     }
 
@@ -247,5 +215,43 @@ class Collection implements ArrayAccess
         $this->last = $collection;
 
         return $this;
+    }
+
+    /** @param array<int, mixed> $children */
+    public static function __callStatic(string $name, array $children): static
+    {
+        $collection = new static();
+
+        return $collection->__call($name, $children);
+    }
+
+    public function __get(string $name): static
+    {
+        if (isset($this->mapper) && isset($this->mapper->$name)) {
+            return $this->stack(clone $this->mapper->$name);
+        }
+
+        return $this->stack(new self($name));
+    }
+
+    /** @param array<int, mixed> $children */
+    public function __call(string $name, array $children): static
+    {
+        if (!isset($this->name)) {
+            $this->name = $name;
+            foreach ($children as $child) {
+                if ($child instanceof Collection) {
+                    $this->addChild($child);
+                } else {
+                    $this->setCondition($child);
+                }
+            }
+
+            return $this;
+        }
+
+        $collection = self::__callStatic($name, $children);
+
+        return $this->stack($collection);
     }
 }

--- a/src/Collections/Filterable.php
+++ b/src/Collections/Filterable.php
@@ -7,5 +7,6 @@ namespace Respect\Data\Collections;
 interface Filterable
 {
     public function getFilters(Collection $collection): mixed;
+
     public function filterable(Collection $collection): mixed;
 }

--- a/src/Collections/Filtered.php
+++ b/src/Collections/Filtered.php
@@ -4,21 +4,24 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
+use function func_get_args;
+
 final class Filtered extends Collection
 {
-    public static function __callStatic(string $name, array $children): static
-    {
-        $collection = new static();
-        $collection->extra('filters', []);
-
-        return $collection->__call($name, $children);
-    }
-
     public static function by(string $name): Collection
     {
         $collection = new Collection();
         $collection->extra('filters', func_get_args());
 
         return $collection;
+    }
+
+    /** @param array<int, mixed> $children */
+    public static function __callStatic(string $name, array $children): static
+    {
+        $collection = new static();
+        $collection->extra('filters', []);
+
+        return $collection->__call($name, $children);
     }
 }

--- a/src/Collections/Mix.php
+++ b/src/Collections/Mix.php
@@ -6,19 +6,20 @@ namespace Respect\Data\Collections;
 
 final class Mix extends Collection
 {
-    public static function __callStatic(string $name, array $children): static
-    {
-        $collection = new static();
-        $collection->extra('mixins', []);
-
-        return $collection->__call($name, $children);
-    }
-
     public static function with(mixed $mixins): Collection
     {
         $collection = new Collection();
         $collection->extra('mixins', $mixins);
 
         return $collection;
+    }
+
+    /** @param array<int, mixed> $children */
+    public static function __callStatic(string $name, array $children): static
+    {
+        $collection = new static();
+        $collection->extra('mixins', []);
+
+        return $collection->__call($name, $children);
     }
 }

--- a/src/Collections/Mixable.php
+++ b/src/Collections/Mixable.php
@@ -7,5 +7,6 @@ namespace Respect\Data\Collections;
 interface Mixable
 {
     public function getMixins(Collection $collection): mixed;
+
     public function mixable(Collection $collection): mixed;
 }

--- a/src/Collections/Typable.php
+++ b/src/Collections/Typable.php
@@ -7,5 +7,6 @@ namespace Respect\Data\Collections;
 interface Typable
 {
     public function getType(Collection $collection): mixed;
+
     public function typable(Collection $collection): mixed;
 }

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -6,19 +6,20 @@ namespace Respect\Data\Collections;
 
 final class Typed extends Collection
 {
-    public static function __callStatic(string $name, array $children): static
-    {
-        $collection = new static();
-        $collection->extra('type', '');
-
-        return $collection->__call($name, $children);
-    }
-
     public static function by(string $type): Collection
     {
         $collection = new Collection();
         $collection->extra('type', $type);
 
         return $collection;
+    }
+
+    /** @param array<int, mixed> $children */
+    public static function __callStatic(string $name, array $children): static
+    {
+        $collection = new static();
+        $collection->extra('type', '');
+
+        return $collection->__call($name, $children);
     }
 }

--- a/src/Styles/AbstractStyle.php
+++ b/src/Styles/AbstractStyle.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
+use function preg_match;
+use function preg_quote;
+use function preg_replace;
+use function preg_replace_callback;
+use function strtoupper;
+
 abstract class AbstractStyle implements Stylable
 {
     protected function camelCaseToSeparator(string $name, string $separator = '_'): string
     {
-        return preg_replace('/(?<=[a-z])([A-Z])/', $separator.'$1', $name);
+        return preg_replace('/(?<=[a-z])([A-Z])/', $separator . '$1', $name);
     }
 
     protected function separatorToCamelCase(string $name, string $separator = '_'): string
@@ -16,9 +22,9 @@ abstract class AbstractStyle implements Stylable
         $separator = preg_quote($separator, '/');
 
         return preg_replace_callback(
-            "/{$separator}([a-zA-Z])/",
-            fn($m) => strtoupper($m[1]),
-            $name
+            '/' . $separator . '([a-zA-Z])/',
+            static fn($m) => strtoupper($m[1]),
+            $name,
         );
     }
 

--- a/src/Styles/CakePHP.php
+++ b/src/Styles/CakePHP.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
+use function array_pop;
+use function explode;
+use function implode;
+use function strtolower;
+use function substr;
+use function ucfirst;
+
 final class CakePHP extends Standard
 {
     public function realName(string $name): string
@@ -18,10 +25,10 @@ final class CakePHP extends Standard
 
     public function remoteIdentifier(string $name): string
     {
-        return $this->pluralToSingular($name).'_id';
+        return $this->pluralToSingular($name) . '_id';
     }
 
-    public function remoteFromIdentifier(string $name): ?string
+    public function remoteFromIdentifier(string $name): string|null
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -3));
@@ -45,6 +52,6 @@ final class CakePHP extends Standard
         $pieces[]   = $this->singularToPlural(array_pop($pieces));
         $right      = implode('_', $pieces);
 
-        return "{$left}_{$right}";
+        return $left . '_' . $right;
     }
 }

--- a/src/Styles/NorthWind.php
+++ b/src/Styles/NorthWind.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
+use function strlen;
+use function strripos;
+use function substr;
+
 final class NorthWind extends Standard
 {
     public function realName(string $name): string
@@ -20,25 +24,25 @@ final class NorthWind extends Standard
     {
         $left = $this->pluralToSingular($left);
 
-        return "{$left}{$right}";
+        return $left . $right;
     }
 
     public function identifier(string $name): string
     {
-        return $this->pluralToSingular($name).'ID';
+        return $this->pluralToSingular($name) . 'ID';
     }
 
     public function remoteIdentifier(string $name): string
     {
-        return $this->pluralToSingular($name).'ID';
+        return $this->pluralToSingular($name) . 'ID';
     }
 
     public function isRemoteIdentifier(string $name): bool
     {
-        return (strlen($name) - 2 === strripos($name, 'ID'));
+        return strlen($name) - 2 === strripos($name, 'ID');
     }
 
-    public function remoteFromIdentifier(string $name): ?string
+    public function remoteFromIdentifier(string $name): string|null
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -2));

--- a/src/Styles/Plural.php
+++ b/src/Styles/Plural.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
+use function array_map;
+use function explode;
+use function implode;
+use function strtolower;
+use function substr;
+use function ucfirst;
+
 /**
  * Default plural table style familiar from frameworks such as Rails, Kohana,
  * Laravel, FuelPHP, etc:
@@ -13,16 +20,15 @@ namespace Respect\Data\Styles;
  * id         id           id           id
  * name       author_id    name         post_id
  *            title                     category_id
- *
  */
 final class Plural extends Standard
 {
     public function remoteIdentifier(string $name): string
     {
-        return $this->pluralToSingular($name).'_id';
+        return $this->pluralToSingular($name) . '_id';
     }
 
-    public function remoteFromIdentifier(string $name): ?string
+    public function remoteFromIdentifier(string $name): string|null
     {
         if ($this->isRemoteIdentifier($name)) {
             return $this->singularToPlural(substr($name, 0, -3));
@@ -52,6 +58,6 @@ final class Plural extends Standard
         $left  = $this->singularToPlural($left);
         $right = $this->singularToPlural($right);
 
-        return "{$left}_{$right}";
+        return $left . '_' . $right;
     }
 }

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Respect\Data\Styles;
 
+use function strlen;
+use function strripos;
+use function strtolower;
+use function substr;
+use function ucfirst;
+
 class Standard extends AbstractStyle
 {
     public function styledProperty(string $name): string
@@ -37,20 +43,20 @@ class Standard extends AbstractStyle
 
     public function remoteIdentifier(string $name): string
     {
-        return $name.'_id';
+        return $name . '_id';
     }
 
     public function composed(string $left, string $right): string
     {
-        return "{$left}_{$right}";
+        return $left . '_' . $right;
     }
 
     public function isRemoteIdentifier(string $name): bool
     {
-        return (strlen($name) - 3 === strripos($name, '_id'));
+        return strlen($name) - 3 === strripos($name, '_id');
     }
 
-    public function remoteFromIdentifier(string $name): ?string
+    public function remoteFromIdentifier(string $name): string|null
     {
         if ($this->isRemoteIdentifier($name)) {
             return substr($name, 0, -3);

--- a/src/Styles/Stylable.php
+++ b/src/Styles/Stylable.php
@@ -18,7 +18,7 @@ interface Stylable
 
     public function remoteIdentifier(string $name): string;
 
-    public function remoteFromIdentifier(string $name): ?string;
+    public function remoteFromIdentifier(string $name): string|null;
 
     public function isRemoteIdentifier(string $name): bool;
 

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -7,6 +7,7 @@ namespace Respect\Data;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionObject;
 use Respect\Data\Collections\Collection;
 
 #[CoversClass(AbstractMapper::class)]
@@ -17,24 +18,24 @@ class AbstractMapperTest extends TestCase
     protected function setUp(): void
     {
         $this->mapper = new class extends AbstractMapper {
+            public function flush(): void
+            {
+            }
+
             protected function createStatement(Collection $fromCollection, mixed $withExtra = null): mixed
             {
                 return null;
-            }
-
-            public function flush(): void
-            {
             }
         };
     }
 
     #[Test]
-    public function registerCollection_should_add_collection_to_pool(): void
+    public function registerCollectionShouldAddCollectionToPool(): void
     {
         $coll = Collection::foo();
         $this->mapper->registerCollection('my_alias', $coll);
 
-        $ref = new \ReflectionObject($this->mapper);
+        $ref = new ReflectionObject($this->mapper);
         $prop = $ref->getProperty('collections');
         $this->assertContains($coll, $prop->getValue($this->mapper));
 
@@ -42,12 +43,12 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function magic_setter_should_add_collection_to_pool(): void
+    public function magicSetterShouldAddCollectionToPool(): void
     {
         $coll = Collection::foo();
         $this->mapper->my_alias = $coll;
 
-        $ref = new \ReflectionObject($this->mapper);
+        $ref = new ReflectionObject($this->mapper);
         $prop = $ref->getProperty('collections');
         $this->assertContains($coll, $prop->getValue($this->mapper));
 
@@ -55,7 +56,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function magic_call_should_bypass_to_collection(): void
+    public function magicCallShouldBypassToCollection(): void
     {
         $collection = $this->mapper->foo()->bar()->baz();
         $expected = Collection::foo();
@@ -64,7 +65,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function magic_getter_should_bypass_to_collection(): void
+    public function magicGetterShouldBypassToCollection(): void
     {
         $collection = $this->mapper->foo->bar->baz;
         $expected = Collection::foo();

--- a/tests/CollectionIteratorTest.php
+++ b/tests/CollectionIteratorTest.php
@@ -9,28 +9,30 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Respect\Data\Collections\Collection;
 
+use function iterator_to_array;
+
 #[CoversClass(CollectionIterator::class)]
 class CollectionIteratorTest extends TestCase
 {
     #[Test]
-    public function static_builder_should_create_recursive_iterator(): void
+    public function staticBuilderShouldCreateRecursiveIterator(): void
     {
         $this->assertInstanceOf(
             'RecursiveIteratorIterator',
-            CollectionIterator::recursive(Collection::foo())
+            CollectionIterator::recursive(Collection::foo()),
         );
     }
 
     #[Test]
-    public function constructing_should_accept_collections_or_arrays(): void
+    public function constructingShouldAcceptCollectionsOrArrays(): void
     {
         $iterator = new CollectionIterator(Collection::foo());
-        $iterator2 = new CollectionIterator(array(Collection::foo()));
+        $iterator2 = new CollectionIterator([Collection::foo()]);
         $this->assertEquals($iterator, $iterator2);
     }
 
     #[Test]
-    public function key_should_track_nameCounts(): void
+    public function keyShouldTrackNameCounts(): void
     {
         $i = new CollectionIterator(Collection::foo());
         $this->assertEquals('foo', $i->key());
@@ -39,7 +41,7 @@ class CollectionIteratorTest extends TestCase
     }
 
     #[Test]
-    public function hasChildren_consider_empties(): void
+    public function hasChildrenConsiderEmpties(): void
     {
         $coll = Collection::foo();
         $iterator = new CollectionIterator($coll);
@@ -47,7 +49,7 @@ class CollectionIteratorTest extends TestCase
     }
 
     #[Test]
-    public function hasChildren_use_collection_children(): void
+    public function hasChildrenUseCollectionChildren(): void
     {
         $coll = Collection::foo(Collection::bar());
         $iterator = new CollectionIterator($coll);
@@ -55,7 +57,7 @@ class CollectionIteratorTest extends TestCase
     }
 
     #[Test]
-    public function hasChildren_use_collection_next(): void
+    public function hasChildrenUseCollectionNext(): void
     {
         $coll = Collection::foo()->bar;
         $iterator = new CollectionIterator($coll);
@@ -63,7 +65,7 @@ class CollectionIteratorTest extends TestCase
     }
 
     #[Test]
-    public function getChildren_consider_empties(): void
+    public function getChildrenConsiderEmpties(): void
     {
         $coll = Collection::foo();
         $iterator = new CollectionIterator($coll);
@@ -71,17 +73,17 @@ class CollectionIteratorTest extends TestCase
     }
 
     #[Test]
-    public function getChildren_use_collection_children(): void
+    public function getChildrenUseCollectionChildren(): void
     {
         $coll = Collection::foo(Collection::bar(), Collection::baz());
-        list($foo_child, $bar_child) = $coll->getChildren();
+        [$fooChild, $barChild] = $coll->getChildren();
         $items = iterator_to_array(CollectionIterator::recursive($coll));
-        $this->assertContains($foo_child, $items);
-        $this->assertContains($bar_child, $items);
+        $this->assertContains($fooChild, $items);
+        $this->assertContains($barChild, $items);
     }
 
     #[Test]
-    public function getChildren_use_collection_next(): void
+    public function getChildrenUseCollectionNext(): void
     {
         $coll = Collection::foo()->bar;
         $iterator = new CollectionIterator($coll);

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -7,31 +7,37 @@ namespace Respect\Data\Collections;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionObject;
 use Respect\Data\AbstractMapper;
+use RuntimeException;
+use stdClass;
+
+use function count;
+use function reset;
 
 #[CoversClass(Collection::class)]
 class CollectionTest extends TestCase
 {
     #[Test]
-    public function collection_can_be_created_statically_with_just_a_name(): void
+    public function collectionCanBeCreatedStaticallyWithJustName(): void
     {
         $coll = Collection::fooBarName();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
     }
 
     #[Test]
-    public function collection_can_be_created_statically_with_children(): void
+    public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children_1 = Collection::bar();
-        $children_2 = Collection::baz();
-        $coll = Collection::foo($children_1, $children_2);
+        $children1 = Collection::bar();
+        $children2 = Collection::baz();
+        $coll = Collection::foo($children1, $children2);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
     }
 
     #[Test]
-    public function collection_can_be_created_statically_with_condition(): void
+    public function collectionCanBeCreatedStaticallyWithCondition(): void
     {
         $coll = Collection::fooBar(42);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
@@ -39,65 +45,70 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function multiple_conditions_on_static_creation_leaves_the_last(): void
+    public function multipleConditionsOnStaticCreationLeavesTheLast(): void
     {
         $coll = Collection::fooBar(42, 'Other dominant condition!!!');
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertEquals(
-            'Other dominant condition!!!', $coll->getCondition()
+            'Other dominant condition!!!',
+            $coll->getCondition(),
         );
     }
 
     #[Test]
-    public function object_constructor_should_set_object_attributes(): void
+    public function objectConstructorShouldSetObjectAttributes(): void
     {
         $coll = new Collection('some_irrelevant_name');
-        $ref = new \ReflectionObject($coll);
+        $ref = new ReflectionObject($coll);
         $prop = $ref->getProperty('last');
         $this->assertSame($coll, $prop->getValue($coll), 'Constructing it manually should set last item as self');
         $this->assertEquals(
-            array(), $coll->getCondition(),
-            'Default condition should be an empty array'
+            [],
+            $coll->getCondition(),
+            'Default condition should be an empty array',
         );
         $this->assertEquals('some_irrelevant_name', $coll->getName());
     }
 
     #[Test]
-    public function object_constructor_with_condition_should_set_it(): void
+    public function objectConstructorWithConditionShouldSetIt(): void
     {
         $coll = new Collection('some_irrelevant_name', 123);
         $this->assertEquals(123, $coll->getCondition());
     }
 
     #[Test]
-    public function dynamic_getter_should_stack_collection(): void
+    public function dynamicGetterShouldStackCollection(): void
     {
         $coll = new Collection('hi');
-        $coll->some_test;
+        $coll->someTest;
         $this->assertEquals(
-            'some_test', $coll->getNextName(),
-            'First time should change next item'
+            'someTest',
+            $coll->getNextName(),
+            'First time should change next item',
         );
     }
 
     #[Test]
-    public function dynamic_getter_should_chain_collection(): void
+    public function dynamicGetterShouldChainCollection(): void
     {
         $coll = new Collection('hi');
-        $coll->some_test;
+        $coll->someTest;
         $this->assertEquals(
-            'some_test', $coll->getNextName(),
-            'First time should change next item'
+            'someTest',
+            $coll->getNextName(),
+            'First time should change next item',
         );
-        $coll->another_test;
+        $coll->anotherTest;
         $this->assertEquals(
-            'some_test', $coll->getNextName(),
-            'The next item on a chain should never be changed after first time'
+            'someTest',
+            $coll->getNextName(),
+            'The next item on a chain should never be changed after first time',
         );
     }
 
     #[Test]
-    public function setting_condition_via_dynamic_offset_should_use_last_node(): void
+    public function settingConditionViaDynamicOffsetShouldUseLastNode(): void
     {
         $foo = Collection::foo()->bar->baz[42];
         $bar = $foo->getNext();
@@ -108,19 +119,19 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function dynamic_method_call_should_accept_children(): void
+    public function dynamicMethodCallShouldAcceptChildren(): void
     {
         $coll = new Collection('some_name');
-        $coll->foo_bar(
+        $coll->fooBar(
             Collection::some(),
             Collection::children(),
-            Collection::here()
+            Collection::here(),
         );
         $this->assertEquals(3, count($coll->getNext()->getChildren()));
     }
 
     #[Test]
-    public function addChild_should_set_children_object_properties(): void
+    public function addChildShouldSetChildrenObjectProperties(): void
     {
         $coll = new Collection('foo_collection');
         $coll->addChild(new Collection('bar_child'));
@@ -131,21 +142,21 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function children_should_make_hasMore_true(): void
+    public function childrenShouldMakeHasMoreTrue(): void
     {
-        $coll = Collection::foo(Collection::this_is_a_children());
+        $coll = Collection::foo(Collection::thisIsAChildren());
         $this->assertTrue($coll->hasMore());
     }
 
     #[Test]
-    public function chaining_should_make_hasMore_true(): void
+    public function chainingShouldMakeHasMoreTrue(): void
     {
         $coll = Collection::foo()->barChain;
         $this->assertTrue($coll->hasMore());
     }
 
     #[Test]
-    public function array_offsetSet_should_NOT_do_anything(): void
+    public function arrayOffsetSetShouldNotDoAnything(): void
     {
         $touched = Collection::foo()->bar;
         $touched['magic'] = 'FOOOO';
@@ -154,7 +165,7 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function array_offsetUnset_should_NOT_do_anything(): void
+    public function arrayOffsetUnsetShouldNotDoAnything(): void
     {
         $touched = Collection::foo()->bar;
         unset($touched['magic']);
@@ -164,91 +175,91 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function persist_should_persist_on_attached_mapper(): void
+    public function persistShouldPersistOnAttachedMapper(): void
     {
-        $persisted = new \stdClass();
+        $persisted = new stdClass();
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('persist')
-                   ->with($persisted, $collection)
-                   ->willReturn(true);
+            ->method('persist')
+            ->with($persisted, $collection)
+            ->willReturn(true);
         $collection->setMapper($mapperMock);
         $collection->persist($persisted);
     }
 
     #[Test]
-    public function remove_should_persist_on_attached_mapper(): void
+    public function removeShouldPersistOnAttachedMapper(): void
     {
-        $removed = new \stdClass();
+        $removed = new stdClass();
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('remove')
-                   ->with($removed, $collection)
-                   ->willReturn(true);
+            ->method('remove')
+            ->with($removed, $collection)
+            ->willReturn(true);
         $collection->setMapper($mapperMock);
         $collection->remove($removed);
     }
 
     #[Test]
-    public function fetch_should_persist_on_attached_mapper(): void
+    public function fetchShouldPersistOnAttachedMapper(): void
     {
         $result = 'result stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('fetch')
-                   ->with($collection)
-                   ->willReturn($result);
+            ->method('fetch')
+            ->with($collection)
+            ->willReturn($result);
         $collection->setMapper($mapperMock);
         $collection->fetch();
     }
 
     #[Test]
-    public function fetch_should_persist_on_attached_mapper_with_extra_param(): void
+    public function fetchShouldPersistOnAttachedMapperWithExtraParam(): void
     {
         $result = 'result stub';
         $extra = 'extra stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('fetch')
-                   ->with($collection, $extra)
-                   ->willReturn($result);
+            ->method('fetch')
+            ->with($collection, $extra)
+            ->willReturn($result);
         $collection->setMapper($mapperMock);
         $collection->fetch($extra);
     }
 
     #[Test]
-    public function fetchAll_should_persist_on_attached_mapper(): void
+    public function fetchAllShouldPersistOnAttachedMapper(): void
     {
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('fetchAll')
-                   ->with($collection)
-                   ->willReturn([]);
+            ->method('fetchAll')
+            ->with($collection)
+            ->willReturn([]);
         $collection->setMapper($mapperMock);
         $collection->fetchAll();
     }
 
     #[Test]
-    public function fetchAll_should_persist_on_attached_mapper_with_extra_param(): void
+    public function fetchAllShouldPersistOnAttachedMapperWithExtraParam(): void
     {
         $extra = 'extra stub';
         $collection = new Collection('name_whatever');
         $mapperMock = $this->createMock(AbstractMapper::class);
         $mapperMock->expects($this->once())
-                   ->method('fetchAll')
-                   ->with($collection, $extra)
-                   ->willReturn([]);
+            ->method('fetchAll')
+            ->with($collection, $extra)
+            ->willReturn([]);
         $collection->setMapper($mapperMock);
         $collection->fetchAll($extra);
     }
 
     #[Test]
-    public function array_offsetExists_should_NOT_do_anything(): void
+    public function arrayOffsetExistsShouldNotDoAnything(): void
     {
         $touched = Collection::foo()->bar;
         $this->assertFalse(isset($touched['magic']));
@@ -257,30 +268,30 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function persist_on_collection_should_exception_if_mapper_dont_exist(): void
+    public function persistOnCollectionShouldExceptionIfMapperDontExist(): void
     {
-        $this->expectException(\RuntimeException::class);
-        Collection::foo()->persist(new \stdClass);
+        $this->expectException(RuntimeException::class);
+        Collection::foo()->persist(new stdClass());
     }
 
     #[Test]
-    public function remove_on_collection_should_exception_if_mapper_dont_exist(): void
+    public function removeOnCollectionShouldExceptionIfMapperDontExist(): void
     {
-        $this->expectException(\RuntimeException::class);
-        Collection::foo()->remove(new \stdClass);
+        $this->expectException(RuntimeException::class);
+        Collection::foo()->remove(new stdClass());
     }
 
     #[Test]
-    public function fetch_on_collection_should_exception_if_mapper_dont_exist(): void
+    public function fetchOnCollectionShouldExceptionIfMapperDontExist(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Collection::foo()->fetch();
     }
 
     #[Test]
-    public function fetchAll_on_collection_should_exception_if_mapper_dont_exist(): void
+    public function fetchAllOnCollectionShouldExceptionIfMapperDontExist(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Collection::foo()->fetchAll();
     }
 }

--- a/tests/Collections/FilteredTest.php
+++ b/tests/Collections/FilteredTest.php
@@ -8,22 +8,24 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+
 #[CoversClass(Filtered::class)]
 class FilteredTest extends TestCase
 {
     #[Test]
-    public function collection_can_be_created_statically_with_children(): void
+    public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children_1 = Filtered::by('bar')->bar();
-        $children_2 = Filtered::by('bat')->baz()->bat();
-        $coll = Collection::foo($children_1, $children_2)->bar();
+        $children1 = Filtered::by('bar')->bar();
+        $children2 = Filtered::by('bat')->baz()->bat();
+        $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_1);
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children1);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(array('bar'), $children_1->getExtra('filters'));
-        $this->assertEquals(array('bat'), $children_2->getExtra('filters'));
+        $this->assertEquals(['bar'], $children1->getExtra('filters'));
+        $this->assertEquals(['bat'], $children2->getExtra('filters'));
     }
 }

--- a/tests/Collections/MixedTest.php
+++ b/tests/Collections/MixedTest.php
@@ -8,22 +8,24 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+
 #[CoversClass(Mix::class)]
 class MixedTest extends TestCase
 {
     #[Test]
-    public function collection_can_be_created_statically_with_children(): void
+    public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children_1 = Mix::with(array('foo' => array('bar')))->bar();
-        $children_2 = Mix::with(array('bat' => array('bar')))->baz()->bat();
-        $coll = Collection::foo($children_1, $children_2)->bar();
+        $children1 = Mix::with(['foo' => ['bar']])->bar();
+        $children2 = Mix::with(['bat' => ['bar']])->baz()->bat();
+        $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_1);
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children1);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(array('foo' => array('bar')), $children_1->getExtra('mixins'));
-        $this->assertEquals(array('bat' => array('bar')), $children_2->getExtra('mixins'));
+        $this->assertEquals(['foo' => ['bar']], $children1->getExtra('mixins'));
+        $this->assertEquals(['bat' => ['bar']], $children2->getExtra('mixins'));
     }
 }

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -8,22 +8,24 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+
 #[CoversClass(Typed::class)]
 class TypedTest extends TestCase
 {
     #[Test]
-    public function collection_can_be_created_statically_with_children(): void
+    public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children_1 = Typed::by('a')->bar();
-        $children_2 = Typed::by('b')->baz()->bat();
-        $coll = Collection::foo($children_1, $children_2)->bar();
+        $children1 = Typed::by('a')->bar();
+        $children2 = Typed::by('b')->baz()->bat();
+        $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll->getNext());
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_1);
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children_2);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children1);
+        $this->assertInstanceOf('Respect\Data\Collections\Collection', $children2);
         $this->assertTrue($coll->hasChildren());
         $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals('a', $children_1->getExtra('type'));
-        $this->assertEquals('b', $children_2->getExtra('type'));
+        $this->assertEquals('a', $children1->getExtra('type'));
+        $this->assertEquals('b', $children2->getExtra('type'));
     }
 }


### PR DESCRIPTION
Run phpcbf auto-fixer on all files to fix whitespace, imports, trailing commas, and brace placement. Manually fix remaining violations: rename snake_case test methods to camelCase, rename snake_case variables to camelCase, replace double-quoted interpolation with concatenation, add traversable PHPDoc type hints, replace is_null() with strict comparison, and suppress SuperfluousAbstractClassNaming for public API classes.