### PR TITLE
Raise PHPStan from level 5 to level 9

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 9
   paths:
     - src/
     - tests/

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -7,16 +7,22 @@ namespace Respect\Data;
 use Respect\Data\Collections\Collection;
 use SplObjectStorage;
 
+use function assert;
+
 abstract class AbstractMapper
 {
     protected Styles\Stylable|null $style = null;
 
+    /** @var SplObjectStorage<object, mixed> */
     protected SplObjectStorage $new;
 
+    /** @var SplObjectStorage<object, mixed> */
     protected SplObjectStorage $tracked;
 
+    /** @var SplObjectStorage<object, mixed> */
     protected SplObjectStorage $changed;
 
+    /** @var SplObjectStorage<object, mixed> */
     protected SplObjectStorage $removed;
 
     /** @var array<string, Collection> */
@@ -33,7 +39,7 @@ abstract class AbstractMapper
     public function getStyle(): Styles\Stylable
     {
         if ($this->style === null) {
-            $this->setStyle(new Styles\Standard());
+            $this->style = new Styles\Standard();
         }
 
         return $this->style;
@@ -125,6 +131,7 @@ abstract class AbstractMapper
 
     public function __set(string $alias, mixed $collection): void
     {
+        assert($collection instanceof Collection);
         $this->registerCollection($alias, $collection);
     }
 

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -6,9 +6,11 @@ namespace Respect\Data;
 
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
+use Respect\Data\Collections\Collection;
 
 use function is_array;
 
+/** @extends RecursiveArrayIterator<array-key, Collection> */
 final class CollectionIterator extends RecursiveArrayIterator
 {
     /** @var array<string, int> */
@@ -19,17 +21,21 @@ final class CollectionIterator extends RecursiveArrayIterator
     {
         $this->namesCounts = &$namesCounts;
 
-        parent::__construct(is_array($target) ? $target : [$target]);
+        /** @var array<Collection> $items */
+        $items = is_array($target) ? $target : [$target];
+
+        parent::__construct($items);
     }
 
+    /** @return RecursiveIteratorIterator<CollectionIterator> */
     public static function recursive(mixed $target): RecursiveIteratorIterator
     {
-        return new RecursiveIteratorIterator(new static($target), 1);
+        return new RecursiveIteratorIterator(new self($target), 1);
     }
 
-    public function key(): string|int|null
+    public function key(): string
     {
-        $name = $this->current()->getName();
+        $name = $this->current()->getName() ?? '';
 
         if (isset($this->namesCounts[$name])) {
             return $name . ++$this->namesCounts[$name];

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -8,6 +8,9 @@ use ArrayAccess;
 use Respect\Data\AbstractMapper;
 use RuntimeException;
 
+use function assert;
+
+/** @implements ArrayAccess<string, Collection> */
 class Collection implements ArrayAccess
 {
     protected bool $required = true;
@@ -163,7 +166,9 @@ class Collection implements ArrayAccess
 
     public function offsetGet(mixed $condition): mixed
     {
-        $this->last->condition = $condition;
+        if ($this->last !== null) {
+            $this->last->condition = $condition;
+        }
 
         return $this;
     }
@@ -211,7 +216,10 @@ class Collection implements ArrayAccess
 
     public function stack(Collection $collection): static
     {
-        $this->last->setNext($collection);
+        if ($this->last !== null) {
+            $this->last->setNext($collection);
+        }
+
         $this->last = $collection;
 
         return $this;
@@ -228,7 +236,10 @@ class Collection implements ArrayAccess
     public function __get(string $name): static
     {
         if (isset($this->mapper) && isset($this->mapper->$name)) {
-            return $this->stack(clone $this->mapper->$name);
+            assert($this->mapper->$name instanceof Collection);
+            $cloned = clone $this->mapper->$name;
+
+            return $this->stack($cloned);
         }
 
         return $this->stack(new self($name));

--- a/src/Styles/AbstractStyle.php
+++ b/src/Styles/AbstractStyle.php
@@ -14,14 +14,14 @@ abstract class AbstractStyle implements Stylable
 {
     protected function camelCaseToSeparator(string $name, string $separator = '_'): string
     {
-        return preg_replace('/(?<=[a-z])([A-Z])/', $separator . '$1', $name);
+        return (string) preg_replace('/(?<=[a-z])([A-Z])/', $separator . '$1', $name);
     }
 
     protected function separatorToCamelCase(string $name, string $separator = '_'): string
     {
         $separator = preg_quote($separator, '/');
 
-        return preg_replace_callback(
+        return (string) preg_replace_callback(
             '/' . $separator . '([a-zA-Z])/',
             static fn($m) => strtoupper($m[1]),
             $name,
@@ -36,7 +36,7 @@ abstract class AbstractStyle implements Stylable
         ];
         foreach ($replacements as $key => $value) {
             if (preg_match($key, $name)) {
-                return preg_replace($key, $value, $name);
+                return (string) preg_replace($key, $value, $name);
             }
         }
 
@@ -51,7 +51,7 @@ abstract class AbstractStyle implements Stylable
         ];
         foreach ($replacements as $key => $value) {
             if (preg_match($key, $name)) {
-                return preg_replace($key, $value, $name);
+                return (string) preg_replace($key, $value, $name);
             }
         }
 

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -43,7 +43,9 @@ class AbstractMapperTest extends TestCase
 
         $ref = new ReflectionObject($this->mapper);
         $prop = $ref->getProperty('collections');
-        $this->assertContains($coll, $prop->getValue($this->mapper));
+        /** @var array<string, Collection> $collections */
+        $collections = $prop->getValue($this->mapper);
+        $this->assertContains($coll, $collections);
 
         $this->assertEquals($coll, $this->mapper->my_alias);
     }
@@ -56,7 +58,9 @@ class AbstractMapperTest extends TestCase
 
         $ref = new ReflectionObject($this->mapper);
         $prop = $ref->getProperty('collections');
-        $this->assertContains($coll, $prop->getValue($this->mapper));
+        /** @var array<string, Collection> $collections */
+        $collections = $prop->getValue($this->mapper);
+        $this->assertContains($coll, $collections);
 
         $this->assertEquals($coll, $this->mapper->my_alias);
     }

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -127,7 +127,9 @@ class CollectionTest extends TestCase
             Collection::children(),
             Collection::here(),
         );
-        $this->assertEquals(3, count($coll->getNext()->getChildren()));
+        $next = $coll->getNext();
+        $this->assertNotNull($next);
+        $this->assertEquals(3, count($next->getChildren()));
     }
 
     #[Test]
@@ -135,8 +137,9 @@ class CollectionTest extends TestCase
     {
         $coll = new Collection('foo_collection');
         $coll->addChild(new Collection('bar_child'));
-        $child = $coll->getChildren();
-        $child = reset($child);
+        $children = $coll->getChildren();
+        $child = reset($children);
+        $this->assertInstanceOf(Collection::class, $child);
         $this->assertEquals(false, $child->isRequired());
         $this->assertEquals($coll->getName(), $child->getParentName());
     }

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -154,10 +154,13 @@ final class InMemoryMapper extends AbstractMapper
             $pk = $this->getStyle()->identifier($tableName);
             $pkValue = $entity->{$pk};
 
-            foreach ($this->tables[$tableName] as $index => $existing) {
+            $rows = $this->tables[$tableName];
+            foreach ($rows as $index => $existing) {
                 if (isset($existing[$pk]) && $existing[$pk] == $pkValue) {
-                    unset($this->tables[$tableName][$index]);
-                    $this->tables[$tableName] = array_values($this->tables[$tableName]);
+                    unset($rows[$index]);
+                    /** @var list<array<string, mixed>> $reindexed */
+                    $reindexed = array_values($rows);
+                    $this->tables[$tableName] = $reindexed;
 
                     break;
                 }


### PR DESCRIPTION
Add generic type parameters to SplObjectStorage properties, CollectionIterator (@extends), Collection (@implements), and RecursiveIteratorIterator return types. Fix null-safety issues in Collection stack/offsetGet, add string casts for preg_replace returns in AbstractStyle, and add type assertions in tests.