### PR TITLE
Extract hydration from Relational into AbstractMapper

### DIFF
--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;
+use Respect\Data\Collections\Composite;
+use Respect\Data\Collections\Filtered;
 use SplObjectStorage;
 
 use function assert;
+use function count;
 
 abstract class AbstractMapper
 {
@@ -63,6 +66,14 @@ abstract class AbstractMapper
 
     public function persist(object $object, Collection $onCollection): bool
     {
+        $next = $onCollection->getNext();
+        if ($onCollection instanceof Filtered && $next !== null) {
+            $next->setMapper($this);
+            $next->persist($object);
+
+            return true;
+        }
+
         $this->changed[$object] = true;
 
         if ($this->isTracked($object)) {
@@ -98,6 +109,75 @@ abstract class AbstractMapper
     {
         $collection->setMapper($this);
         $this->collections[$alias] = $collection;
+    }
+
+    /** @param SplObjectStorage<object, Collection> $entities */
+    protected function postHydrate(SplObjectStorage $entities): void
+    {
+        $entitiesClone = clone $entities;
+
+        foreach ($entities as $instance) {
+            foreach ($this->entityFactory->extractProperties($instance) as $field => $v) {
+                if (!$this->getStyle()->isRemoteIdentifier($field)) {
+                    continue;
+                }
+
+                foreach ($entitiesClone as $sub) {
+                    $this->tryHydration($entities, $sub, $field, $v);
+                }
+
+                $this->entityFactory->set($instance, $field, $v);
+            }
+        }
+    }
+
+    /** @param SplObjectStorage<object, Collection> $entities */
+    protected function tryHydration(SplObjectStorage $entities, object $sub, string $field, mixed &$v): void
+    {
+        $tableName = (string) $entities[$sub]->getName();
+        $primaryName = $this->getStyle()->identifier($tableName);
+
+        if (
+            $tableName !== $this->getStyle()->remoteFromIdentifier($field)
+                || $this->entityFactory->get($sub, $primaryName) != $v
+        ) {
+            return;
+        }
+
+        $v = $sub;
+    }
+
+    /**
+     * @param SplObjectStorage<object, Collection> $entities
+     *
+     * @return array<int, object>
+     */
+    protected function buildEntitiesInstances(
+        Collection $collection,
+        SplObjectStorage $entities,
+    ): array {
+        $entitiesInstances = [];
+
+        foreach (CollectionIterator::recursive($collection) as $c) {
+            assert($c instanceof Collection);
+            if ($c instanceof Filtered && !$c->getFilters()) {
+                continue;
+            }
+
+            $entityInstance = $this->entityFactory->createByName((string) $c->getName());
+
+            if ($c instanceof Composite) {
+                $compositionCount = count($c->getCompositions());
+                for ($i = 0; $i < $compositionCount; $i++) {
+                    $entitiesInstances[] = $entityInstance;
+                }
+            }
+
+            $entities[$entityInstance] = $c;
+            $entitiesInstances[] = $entityInstance;
+        }
+
+        return $entitiesInstances;
     }
 
     public function __get(string $name): Collection

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -6,6 +6,7 @@ namespace Respect\Data\Collections;
 
 use ArrayAccess;
 use Respect\Data\AbstractMapper;
+use Respect\Data\EntityFactory;
 use RuntimeException;
 
 use function assert;
@@ -98,6 +99,11 @@ class Collection implements ArrayAccess
     public function getName(): string|null
     {
         return $this->name;
+    }
+
+    public function resolveEntityName(EntityFactory $factory, object $row): string
+    {
+        return $this->name ?? '';
     }
 
     public function getNext(): Collection|null

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Respect\Data\Collections;
 
+use Respect\Data\EntityFactory;
+
+use function is_string;
+
 final class Typed extends Collection
 {
     private string $type = '';
@@ -19,6 +23,13 @@ final class Typed extends Collection
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function resolveEntityName(EntityFactory $factory, object $row): string
+    {
+        $name = $factory->get($row, $this->type);
+
+        return is_string($name) ? $name : ($this->getName() ?? '');
     }
 
     /** @param array<int, mixed> $children */

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Respect\Data\Collections\Collection;
+use Respect\Data\Collections\Filtered;
 use Respect\Data\Styles\CakePHP;
 use Respect\Data\Styles\Standard;
 use SplObjectStorage;
@@ -225,5 +226,92 @@ class AbstractMapperTest extends TestCase
         $coll = $this->mapper->unregistered;
         $this->assertInstanceOf(Collection::class, $coll);
         $this->assertEquals('unregistered', $coll->getName());
+    }
+
+    #[Test]
+    public function postHydrateReplacesFkWithMatchingEntity(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('comment', [
+            ['id' => 1, 'text' => 'Hello', 'post_id' => 5],
+        ]);
+        $mapper->seed('post', [
+            ['id' => 5, 'title' => 'Post'],
+        ]);
+
+        $comment = $mapper->comment->post->fetch();
+        $this->assertIsObject($comment);
+        $post = $mapper->entityFactory->get($comment, 'post_id');
+        $this->assertIsObject($post);
+        $this->assertEquals(5, $mapper->entityFactory->get($post, 'id'));
+        $this->assertEquals('Post', $mapper->entityFactory->get($post, 'title'));
+    }
+
+    #[Test]
+    public function postHydrateLeavesFkUnchangedWhenNoMatch(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('comment', [
+            ['id' => 1, 'text' => 'Hello', 'post_id' => 999],
+        ]);
+        $mapper->seed('post', [
+            ['id' => 5, 'title' => 'Post'],
+        ]);
+
+        $comment = $mapper->comment->post->fetch();
+        $this->assertIsObject($comment);
+        $this->assertEquals(999, $mapper->entityFactory->get($comment, 'post_id'));
+    }
+
+    #[Test]
+    public function postHydrateMatchesIntFkToStringPk(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('comment', [
+            ['id' => 1, 'text' => 'Hello', 'post_id' => 5],
+        ]);
+        $mapper->seed('post', [
+            ['id' => '5', 'title' => 'Post'],
+        ]);
+
+        $comment = $mapper->comment->post->fetch();
+        $this->assertIsObject($comment);
+        $post = $mapper->entityFactory->get($comment, 'post_id');
+        $this->assertIsObject($post);
+        $this->assertEquals('5', $mapper->entityFactory->get($post, 'id'));
+    }
+
+    #[Test]
+    public function filteredPersistDelegatesToParentCollection(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('post', []);
+        $mapper->seed('author', []);
+        $mapper->authorsWithPosts = Filtered::post()->author();
+
+        $author = new stdClass();
+        $author->id = null;
+        $author->name = 'Test';
+        $mapper->authorsWithPosts->persist($author);
+        $mapper->flush();
+
+        $fetched = $mapper->author->fetch();
+        $this->assertEquals('Test', $fetched->name);
+    }
+
+    #[Test]
+    public function filteredWithoutNextFallsBackToNormalPersist(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('post', []);
+
+        $post = new stdClass();
+        $post->id = null;
+        $post->title = 'Direct';
+        $mapper->post->persist($post);
+        $mapper->flush();
+
+        $fetched = $mapper->post->fetch();
+        $this->assertEquals('Direct', $fetched->title);
     }
 }

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -7,6 +7,8 @@ namespace Respect\Data\Collections;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Respect\Data\EntityFactory;
+use stdClass;
 
 use function count;
 
@@ -36,5 +38,24 @@ class TypedTest extends TestCase
         $this->assertInstanceOf(Typed::class, $coll);
         $this->assertEquals('items', $coll->getName());
         $this->assertEquals('', $coll->getType());
+    }
+
+    #[Test]
+    public function resolveEntityNameReturnsDiscriminatorValue(): void
+    {
+        $coll = Typed::by('type')->issues();
+        $factory = new EntityFactory();
+        $row = new stdClass();
+        $row->type = 'Bug';
+        $this->assertEquals('Bug', $coll->resolveEntityName($factory, $row));
+    }
+
+    #[Test]
+    public function resolveEntityNameFallsBackToCollectionName(): void
+    {
+        $coll = Typed::by('type')->issues();
+        $factory = new EntityFactory();
+        $row = new stdClass();
+        $this->assertEquals('issues', $coll->resolveEntityName($factory, $row));
     }
 }

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;
+use SplObjectStorage;
+use stdClass;
 
 use function array_filter;
 use function array_values;
@@ -28,33 +30,26 @@ final class InMemoryMapper extends AbstractMapper
     public function fetch(Collection $collection, mixed $extra = null): mixed
     {
         $name = (string) $collection->getName();
-        $rows = $this->tables[$name] ?? [];
-        $condition = $collection->getCondition();
-        $style = $this->getStyle();
+        $row = $this->findRow($name, $collection->getCondition());
 
-        if ($condition !== null && $condition !== []) {
-            $pk = $style->identifier($name);
-            $pkValue = is_array($condition) ? reset($condition) : $condition;
-            $rows = array_values(array_filter(
-                $rows,
-                static fn(array $row): bool => isset($row[$pk]) && $row[$pk] == $pkValue,
-            ));
-        }
-
-        if ($rows === []) {
+        if ($row === null) {
             return false;
         }
 
-        $row = $rows[0];
-        $factory = $this->entityFactory;
-        $entity = $factory->createByName($name);
+        $rowObject = $this->rowToObject($row);
+        $entityName = $collection->resolveEntityName($this->entityFactory, $rowObject);
+        $entity = $this->entityFactory->createByName($entityName);
 
         foreach ($row as $key => $value) {
-            $factory->set($entity, $key, $value);
+            $this->entityFactory->set($entity, $key, $value);
         }
 
         if ($collection->hasMore()) {
-            $this->resolveRelations($entity, $collection);
+            /** @var SplObjectStorage<object, Collection> $entities */
+            $entities = new SplObjectStorage();
+            $entities[$entity] = $collection;
+            $this->fetchRelated($entity, $collection, $entities);
+            $this->postHydrate($entities);
         }
 
         $this->markTracked($entity, $collection);
@@ -66,55 +61,45 @@ final class InMemoryMapper extends AbstractMapper
     public function fetchAll(Collection $collection, mixed $extra = null): array
     {
         $name = (string) $collection->getName();
-        $rows = $this->tables[$name] ?? [];
-        $condition = $collection->getCondition();
-        $style = $this->getStyle();
-
-        if ($condition !== null && $condition !== []) {
-            $pk = $style->identifier($name);
-            $pkValue = is_array($condition) ? reset($condition) : $condition;
-            $rows = array_values(array_filter(
-                $rows,
-                static fn(array $row): bool => isset($row[$pk]) && $row[$pk] == $pkValue,
-            ));
-        }
-
-        $entities = [];
-
-        $factory = $this->entityFactory;
+        $rows = $this->findRows($name, $collection->getCondition());
+        $result = [];
 
         foreach ($rows as $row) {
-            $entity = $factory->createByName($name);
+            $rowObject = $this->rowToObject($row);
+            $entityName = $collection->resolveEntityName($this->entityFactory, $rowObject);
+            $entity = $this->entityFactory->createByName($entityName);
 
             foreach ($row as $key => $value) {
-                $factory->set($entity, $key, $value);
+                $this->entityFactory->set($entity, $key, $value);
             }
 
             if ($collection->hasMore()) {
-                $this->resolveRelations($entity, $collection);
+                /** @var SplObjectStorage<object, Collection> $entities */
+                $entities = new SplObjectStorage();
+                $entities[$entity] = $collection;
+                $this->fetchRelated($entity, $collection, $entities);
+                $this->postHydrate($entities);
             }
 
             $this->markTracked($entity, $collection);
-            $entities[] = $entity;
+            $result[] = $entity;
         }
 
-        return $entities;
+        return $result;
     }
 
     public function flush(): void
     {
-        $factory = $this->entityFactory;
-
         foreach ($this->new as $entity) {
             $collection = $this->tracked[$entity];
             assert($collection instanceof Collection);
             $tableName = (string) $collection->getName();
             $pk = $this->getStyle()->identifier($tableName);
-            $row = $factory->extractProperties($entity);
+            $row = $this->entityFactory->extractProperties($entity);
 
             if (!isset($row[$pk])) {
                 ++$this->lastInsertId;
-                $factory->set($entity, $pk, $this->lastInsertId);
+                $this->entityFactory->set($entity, $pk, $this->lastInsertId);
                 $row[$pk] = $this->lastInsertId;
             }
 
@@ -134,8 +119,8 @@ final class InMemoryMapper extends AbstractMapper
             assert($collection instanceof Collection);
             $tableName = (string) $collection->getName();
             $pk = $this->getStyle()->identifier($tableName);
-            $pkValue = $factory->get($entity, $pk);
-            $row = $factory->extractProperties($entity);
+            $pkValue = $this->entityFactory->get($entity, $pk);
+            $row = $this->entityFactory->extractProperties($entity);
 
             foreach ($this->tables[$tableName] as $index => $existing) {
                 if (isset($existing[$pk]) && $existing[$pk] == $pkValue) {
@@ -151,7 +136,7 @@ final class InMemoryMapper extends AbstractMapper
             assert($collection instanceof Collection);
             $tableName = (string) $collection->getName();
             $pk = $this->getStyle()->identifier($tableName);
-            $pkValue = $factory->get($entity, $pk);
+            $pkValue = $this->entityFactory->get($entity, $pk);
 
             $rows = $this->tables[$tableName];
             foreach ($rows as $index => $existing) {
@@ -169,72 +154,105 @@ final class InMemoryMapper extends AbstractMapper
         $this->reset();
     }
 
-    private function resolveRelations(object $entity, Collection $collection): void
+    /** @param SplObjectStorage<object, Collection> $entities */
+    private function fetchRelated(object $parent, Collection $collection, SplObjectStorage $entities): void
     {
-        $style = $this->getStyle();
-        $factory = $this->entityFactory;
         $next = $collection->getNext();
 
         if ($next !== null) {
-            $nextName = (string) $next->getName();
-            $fkCol = $style->remoteIdentifier($nextName);
-            $fkValue = $factory->get($entity, $fkCol);
-
-            if ($fkValue !== null) {
-                $childEntity = $this->findRelatedEntity($nextName, $fkValue, $next);
-
-                if ($childEntity !== null) {
-                    $factory->set($entity, $fkCol, $childEntity);
-                }
-            }
+            $this->fetchRelatedCollection($parent, $next, $entities);
         }
 
         foreach ($collection->getChildren() as $child) {
-            $childName = (string) $child->getName();
-            $fkCol = $style->remoteIdentifier($childName);
-            $fkValue = $factory->get($entity, $fkCol);
-
-            if ($fkValue === null) {
-                continue;
-            }
-
-            $childEntity = $this->findRelatedEntity($childName, $fkValue, $child);
-
-            if ($childEntity === null) {
-                continue;
-            }
-
-            $factory->set($entity, $fkCol, $childEntity);
+            $this->fetchRelatedCollection($parent, $child, $entities);
         }
     }
 
-    private function findRelatedEntity(string $tableName, mixed $fkValue, Collection $collection): object|null
+    /** @param SplObjectStorage<object, Collection> $entities */
+    private function fetchRelatedCollection(
+        object $parent,
+        Collection $related,
+        SplObjectStorage $entities,
+    ): void {
+        $relatedName = (string) $related->getName();
+        $fkCol = $this->getStyle()->remoteIdentifier($relatedName);
+        $fkValue = $this->entityFactory->get($parent, $fkCol);
+
+        if ($fkValue === null) {
+            return;
+        }
+
+        $pk = $this->getStyle()->identifier($relatedName);
+        $row = $this->findRowByPk($relatedName, $pk, $fkValue);
+
+        if ($row === null) {
+            return;
+        }
+
+        $rowObject = $this->rowToObject($row);
+        $entityName = $related->resolveEntityName($this->entityFactory, $rowObject);
+        $childEntity = $this->entityFactory->createByName($entityName);
+
+        foreach ($row as $key => $value) {
+            $this->entityFactory->set($childEntity, $key, $value);
+        }
+
+        $entities[$childEntity] = $related;
+        $this->markTracked($childEntity, $related);
+
+        if (!$related->hasMore()) {
+            return;
+        }
+
+        $this->fetchRelated($childEntity, $related, $entities);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function findRow(string $table, mixed $condition): array|null
     {
-        $style = $this->getStyle();
-        $factory = $this->entityFactory;
-        $pk = $style->identifier($tableName);
-        $rows = $this->tables[$tableName] ?? [];
+        $rows = $this->findRows($table, $condition);
 
-        foreach ($rows as $row) {
-            if (!isset($row[$pk]) || $row[$pk] != $fkValue) {
-                continue;
+        return $rows[0] ?? null;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function findRows(string $table, mixed $condition): array
+    {
+        $rows = $this->tables[$table] ?? [];
+
+        if ($condition === null || $condition === []) {
+            return $rows;
+        }
+
+        $pk = $this->getStyle()->identifier($table);
+        $pkValue = is_array($condition) ? reset($condition) : $condition;
+
+        return array_values(array_filter(
+            $rows,
+            static fn(array $row): bool => isset($row[$pk]) && $row[$pk] == $pkValue,
+        ));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function findRowByPk(string $table, string $pk, mixed $pkValue): array|null
+    {
+        foreach ($this->tables[$table] ?? [] as $row) {
+            if (isset($row[$pk]) && $row[$pk] == $pkValue) {
+                return $row;
             }
-
-            $childEntity = $factory->createByName($tableName);
-
-            foreach ($row as $key => $value) {
-                $factory->set($childEntity, $key, $value);
-            }
-
-            if ($collection->hasMore()) {
-                $this->resolveRelations($childEntity, $collection);
-            }
-
-            $this->markTracked($childEntity, $collection);
-
-            return $childEntity;
         }
 
         return null;
+    }
+
+    /** @param array<string, mixed> $row */
+    private function rowToObject(array $row): object
+    {
+        $obj = new stdClass();
+        foreach ($row as $key => $value) {
+            $obj->{$key} = $value;
+        }
+
+        return $obj;
     }
 }


### PR DESCRIPTION
- Add resolveEntityName() to Collection with polymorphic override in Typed that reads the discriminator column via EntityFactory
- Move Filtered persist delegation to AbstractMapper::persist(), so any backend routes filtered collections to their parent automatically
- Move postHydrate()/tryHydration() to AbstractMapper as protected methods for FK-to-object wiring using Style naming conventions
- Move buildEntitiesInstances() to AbstractMapper for collection-tree entity creation with Filtered skip and Composite duplication
- Rewrite InMemoryMapper to use shared postHydrate() instead of custom resolveRelations(), proving the abstraction works outside SQL
- InMemoryMapper now supports Typed collections via resolveEntityName()
- Remove unnecessary local variable aliases for $this->entityFactory