### PR TITLE
Modernize properties with PHP 8.4+ features and tighten visibility

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,6 +16,9 @@
 
     <rule ref="Respect">
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix" />
+        <!-- PHPCS 4.0.x cannot parse property hooks (PHP 8.4+), remove when fixed -->
+        <exclude name="PSR2.Classes.PropertyDeclaration.Multiple" />
+        <exclude name="PSR2.Classes.PropertyDeclaration.ScopeMissing" />
     </rule>
 
     <!-- Test code and stub entities use snake_case properties matching DB columns -->

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -9,25 +9,26 @@ use Respect\Data\Collections\Composite;
 use Respect\Data\Collections\Filtered;
 use SplObjectStorage;
 
-use function assert;
 use function count;
 
 abstract class AbstractMapper
 {
-    /** @var SplObjectStorage<object, mixed> */
+    /** @var SplObjectStorage<object, true> */
     protected SplObjectStorage $new;
 
-    /** @var SplObjectStorage<object, mixed> */
+    /** @var SplObjectStorage<object, Collection> */
     protected SplObjectStorage $tracked;
 
-    /** @var SplObjectStorage<object, mixed> */
+    /** @var SplObjectStorage<object, true> */
     protected SplObjectStorage $changed;
 
-    /** @var SplObjectStorage<object, mixed> */
+    /** @var SplObjectStorage<object, true> */
     protected SplObjectStorage $removed;
 
     /** @var array<string, Collection> */
-    protected array $collections = [];
+    private array $collections = [];
+
+    public Styles\Stylable $style { get => $this->entityFactory->style; }
 
     public function __construct(
         public readonly EntityFactory $entityFactory = new EntityFactory(),
@@ -36,11 +37,6 @@ abstract class AbstractMapper
         $this->changed  = new SplObjectStorage();
         $this->removed  = new SplObjectStorage();
         $this->new      = new SplObjectStorage();
-    }
-
-    public function getStyle(): Styles\Stylable
-    {
-        return $this->entityFactory->style;
     }
 
     abstract public function flush(): void;
@@ -66,10 +62,9 @@ abstract class AbstractMapper
 
     public function persist(object $object, Collection $onCollection): bool
     {
-        $next = $onCollection->getNext();
+        $next = $onCollection->next;
         if ($onCollection instanceof Filtered && $next !== null) {
-            $next->setMapper($this);
-            $next->persist($object);
+            $this->persist($object, $next);
 
             return true;
         }
@@ -107,7 +102,7 @@ abstract class AbstractMapper
 
     public function registerCollection(string $alias, Collection $collection): void
     {
-        $collection->setMapper($this);
+        $collection->mapper = $this;
         $this->collections[$alias] = $collection;
     }
 
@@ -118,7 +113,7 @@ abstract class AbstractMapper
 
         foreach ($entities as $instance) {
             foreach ($this->entityFactory->extractProperties($instance) as $field => $v) {
-                if (!$this->getStyle()->isRemoteIdentifier($field)) {
+                if (!$this->style->isRemoteIdentifier($field)) {
                     continue;
                 }
 
@@ -129,22 +124,6 @@ abstract class AbstractMapper
                 $this->entityFactory->set($instance, $field, $v);
             }
         }
-    }
-
-    /** @param SplObjectStorage<object, Collection> $entities */
-    protected function tryHydration(SplObjectStorage $entities, object $sub, string $field, mixed &$v): void
-    {
-        $tableName = (string) $entities[$sub]->getName();
-        $primaryName = $this->getStyle()->identifier($tableName);
-
-        if (
-            $tableName !== $this->getStyle()->remoteFromIdentifier($field)
-                || $this->entityFactory->get($sub, $primaryName) != $v
-        ) {
-            return;
-        }
-
-        $v = $sub;
     }
 
     /**
@@ -159,15 +138,18 @@ abstract class AbstractMapper
         $entitiesInstances = [];
 
         foreach (CollectionIterator::recursive($collection) as $c) {
-            assert($c instanceof Collection);
-            if ($c instanceof Filtered && !$c->getFilters()) {
+            if (!$c instanceof Collection) {
                 continue;
             }
 
-            $entityInstance = $this->entityFactory->createByName((string) $c->getName());
+            if ($c instanceof Filtered && !$c->filters) {
+                continue;
+            }
+
+            $entityInstance = $this->entityFactory->createByName((string) $c->name);
 
             if ($c instanceof Composite) {
-                $compositionCount = count($c->getCompositions());
+                $compositionCount = count($c->compositions);
                 for ($i = 0; $i < $compositionCount; $i++) {
                     $entitiesInstances[] = $entityInstance;
                 }
@@ -180,6 +162,22 @@ abstract class AbstractMapper
         return $entitiesInstances;
     }
 
+    /** @param SplObjectStorage<object, Collection> $entities */
+    private function tryHydration(SplObjectStorage $entities, object $sub, string $field, mixed &$v): void
+    {
+        $tableName = (string) $entities[$sub]->name;
+        $primaryName = $this->style->identifier($tableName);
+
+        if (
+            $tableName !== $this->style->remoteFromIdentifier($field)
+                || $this->entityFactory->get($sub, $primaryName) != $v
+        ) {
+            return;
+        }
+
+        $v = $sub;
+    }
+
     public function __get(string $name): Collection
     {
         if (isset($this->collections[$name])) {
@@ -187,7 +185,7 @@ abstract class AbstractMapper
         }
 
         $coll = new Collection($name);
-        $coll->setMapper($this);
+        $coll->mapper = $this;
 
         return $coll;
     }
@@ -197,9 +195,8 @@ abstract class AbstractMapper
         return isset($this->collections[$alias]);
     }
 
-    public function __set(string $alias, mixed $collection): void
+    public function __set(string $alias, Collection $collection): void
     {
-        assert($collection instanceof Collection);
         $this->registerCollection($alias, $collection);
     }
 
@@ -207,7 +204,7 @@ abstract class AbstractMapper
     public function __call(string $name, array $children): Collection
     {
         $collection = Collection::__callstatic($name, $children);
-        $collection->setMapper($this);
+        $collection->mapper = $this;
 
         return $collection;
     }

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -16,26 +16,28 @@ final class CollectionIterator extends RecursiveArrayIterator
     /** @var array<string, int> */
     protected array $namesCounts = [];
 
-    /** @param array<string, int> $namesCounts */
-    public function __construct(mixed $target = [], array &$namesCounts = [])
+    /**
+     * @param Collection|array<Collection> $target
+     * @param array<string, int> $namesCounts
+     */
+    public function __construct(Collection|array $target = [], array &$namesCounts = [])
     {
         $this->namesCounts = &$namesCounts;
 
-        /** @var array<Collection> $items */
         $items = is_array($target) ? $target : [$target];
 
         parent::__construct($items);
     }
 
     /** @return RecursiveIteratorIterator<CollectionIterator> */
-    public static function recursive(mixed $target): RecursiveIteratorIterator
+    public static function recursive(Collection $target): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(new self($target), 1);
     }
 
     public function key(): string
     {
-        $name = $this->current()->getName() ?? '';
+        $name = $this->current()->name ?? '';
 
         if (isset($this->namesCounts[$name])) {
             return $name . ++$this->namesCounts[$name];
@@ -48,20 +50,15 @@ final class CollectionIterator extends RecursiveArrayIterator
 
     public function hasChildren(): bool
     {
-        return $this->current()->hasMore();
+        return $this->current()->more;
     }
 
     public function getChildren(): RecursiveArrayIterator
     {
         $c = $this->current();
-        $pool = [];
-
-        if ($c->hasChildren()) {
-            $pool = $c->getChildren();
-        }
-
-        if ($c->hasNext()) {
-            $pool[] = $c->getNext();
+        $pool = $c->hasChildren ? $c->children : [];
+        if ($c->next !== null) {
+            $pool[] = $c->next;
         }
 
         return new static($pool, $this->namesCounts);

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -9,131 +9,73 @@ use Respect\Data\AbstractMapper;
 use Respect\Data\EntityFactory;
 use RuntimeException;
 
-use function assert;
+use function is_array;
+use function is_scalar;
 
 /** @implements ArrayAccess<string, Collection> */
 class Collection implements ArrayAccess
 {
-    protected bool $required = true;
+    public private(set) bool $required = true;
 
-    protected AbstractMapper|null $mapper = null;
+    public AbstractMapper|null $mapper = null;
 
-    protected Collection|null $parent = null;
+    public private(set) Collection|null $parent = null;
 
-    protected Collection|null $next = null;
+    public private(set) Collection|null $next = null;
 
-    protected Collection|null $last = null;
+    private Collection|null $last = null;
 
     /** @var Collection[] */
-    protected array $children = [];
+    public private(set) array $children = [];
 
-    public function __construct(protected string|null $name = null, protected mixed $condition = [])
-    {
-        $this->last = $this;
+    public bool $hasChildren { get => !empty($this->children); }
+
+    public bool $more { get => $this->hasChildren || $this->next !== null; }
+
+    /** @param array<mixed>|scalar|null $condition */
+    public function __construct(
+        public private(set) string|null $name = null,
+        public private(set) array|int|float|string|bool|null $condition = [],
+    ) {
     }
 
-    public static function using(mixed $condition): static
+    /** @param array<mixed>|scalar|null $condition */
+    public static function using(array|int|float|string|bool|null $condition): static
     {
-        $collection = new static();
-        $collection->setCondition($condition);
-
-        return $collection;
+        return new static(condition: $condition);
     }
 
     public function addChild(Collection $child): void
     {
         $clone = clone $child;
-        $clone->setRequired(false);
-        $clone->setMapper($this->mapper);
-        $clone->setParent($this);
+        $clone->required = false;
+        $clone->parent = $this;
         $this->children[] = $clone;
     }
 
-    public function persist(object $object): mixed
+    public function persist(object $object): bool
     {
-        if (!$this->mapper) {
-            throw new RuntimeException();
-        }
-
-        return $this->mapper->persist($object, $this);
+        return $this->resolveMapper()->persist($object, $this);
     }
 
-    public function remove(object $object): mixed
+    public function remove(object $object): bool
     {
-        if (!$this->mapper) {
-            throw new RuntimeException();
-        }
-
-        return $this->mapper->remove($object, $this);
+        return $this->resolveMapper()->remove($object, $this);
     }
 
     public function fetch(mixed $extra = null): mixed
     {
-        if (!$this->mapper) {
-            throw new RuntimeException();
-        }
-
-        return $this->mapper->fetch($this, $extra);
+        return $this->resolveMapper()->fetch($this, $extra);
     }
 
     public function fetchAll(mixed $extra = null): mixed
     {
-        if (!$this->mapper) {
-            throw new RuntimeException();
-        }
-
-        return $this->mapper->fetchAll($this, $extra);
-    }
-
-    /** @return Collection[] */
-    public function getChildren(): array
-    {
-        return $this->children;
-    }
-
-    public function getCondition(): mixed
-    {
-        return $this->condition;
-    }
-
-    public function getName(): string|null
-    {
-        return $this->name;
+        return $this->resolveMapper()->fetchAll($this, $extra);
     }
 
     public function resolveEntityName(EntityFactory $factory, object $row): string
     {
         return $this->name ?? '';
-    }
-
-    public function getNext(): Collection|null
-    {
-        return $this->next;
-    }
-
-    public function getParent(): Collection|null
-    {
-        return $this->parent;
-    }
-
-    public function hasChildren(): bool
-    {
-        return !empty($this->children);
-    }
-
-    public function hasMore(): bool
-    {
-        return $this->hasChildren() || $this->hasNext();
-    }
-
-    public function hasNext(): bool
-    {
-        return $this->next !== null;
-    }
-
-    public function isRequired(): bool
-    {
-        return $this->required;
     }
 
     public function offsetExists(mixed $offset): bool
@@ -143,7 +85,8 @@ class Collection implements ArrayAccess
 
     public function offsetGet(mixed $condition): mixed
     {
-        $this->last?->setCondition($condition);
+        $tail = $this->last ?? $this;
+        $tail->condition = $condition;
 
         return $this;
     }
@@ -158,43 +101,38 @@ class Collection implements ArrayAccess
         // no-op
     }
 
-    public function setCondition(mixed $condition): void
-    {
-        $this->condition = $condition;
-    }
-
-    public function setMapper(AbstractMapper|null $mapper = null): void
-    {
-        foreach ($this->children as $child) {
-            $child->setMapper($mapper);
-        }
-
-        $this->mapper = $mapper;
-    }
-
-    public function setParent(Collection $parent): void
-    {
-        $this->parent = $parent;
-    }
-
-    public function setNext(Collection $collection): void
-    {
-        $collection->setParent($this);
-        $collection->setMapper($this->mapper);
-        $this->next = $collection;
-    }
-
-    public function setRequired(bool $required): void
-    {
-        $this->required = $required;
-    }
-
     public function stack(Collection $collection): static
     {
-        $this->last?->setNext($collection);
-        $this->last = $collection;
+        $tail = $this->last ?? $this;
+        $tail->setNext($collection);
+        $this->last = $collection->last ?? $collection;
 
         return $this;
+    }
+
+    private function findMapper(): AbstractMapper|null
+    {
+        $node = $this;
+        while ($node !== null) {
+            if ($node->mapper !== null) {
+                return $node->mapper;
+            }
+
+            $node = $node->parent;
+        }
+
+        return null;
+    }
+
+    private function resolveMapper(): AbstractMapper
+    {
+        return $this->findMapper() ?? throw new RuntimeException();
+    }
+
+    private function setNext(Collection $collection): void
+    {
+        $collection->parent = $this;
+        $this->next = $collection;
     }
 
     /** @param array<int, mixed> $children */
@@ -207,11 +145,9 @@ class Collection implements ArrayAccess
 
     public function __get(string $name): static
     {
-        if (isset($this->mapper) && isset($this->mapper->$name)) {
-            assert($this->mapper->$name instanceof Collection);
-            $cloned = clone $this->mapper->$name;
-
-            return $this->stack($cloned);
+        $mapper = $this->findMapper();
+        if ($mapper !== null && isset($mapper->$name)) {
+            return $this->stack(clone $mapper->__get($name));
         }
 
         return $this->stack(new self($name));
@@ -225,17 +161,14 @@ class Collection implements ArrayAccess
             foreach ($children as $child) {
                 if ($child instanceof Collection) {
                     $this->addChild($child);
-                } else {
-                    $this->setCondition($child);
+                } elseif (is_array($child) || is_scalar($child) || $child === null) {
+                    $this->condition = $child;
                 }
             }
 
             return $this;
         }
 
-        $collection = new Collection();
-        $collection->__call($name, $children);
-
-        return $this->stack($collection);
+        return $this->stack((new Collection())->__call($name, $children));
     }
 }

--- a/src/Collections/Composite.php
+++ b/src/Collections/Composite.php
@@ -6,22 +6,22 @@ namespace Respect\Data\Collections;
 
 final class Composite extends Collection
 {
-    /** @var array<string, list<string>> */
-    private array $compositions = [];
+    /**
+     * @param array<string, list<string>> $compositions
+     * @param array<mixed>|scalar|null $condition
+     */
+    public function __construct(
+        public private(set) readonly array $compositions = [],
+        string|null $name = null,
+        array|int|float|string|bool|null $condition = [],
+    ) {
+        parent::__construct($name, $condition);
+    }
 
     /** @param array<string, list<string>> $compositions */
     public static function with(array $compositions): static
     {
-        $collection = new static();
-        $collection->compositions = $compositions;
-
-        return $collection;
-    }
-
-    /** @return array<string, list<string>> */
-    public function getCompositions(): array
-    {
-        return $this->compositions;
+        return new static(compositions: $compositions);
     }
 
     /** @param array<int, mixed> $children */

--- a/src/Collections/Filtered.php
+++ b/src/Collections/Filtered.php
@@ -11,26 +11,24 @@ final class Filtered extends Collection
     /** Fetch only the entity identifier (primary key, document ID, etc.) */
     public const string IDENTIFIER_ONLY = '*';
 
-    /** @var list<string> */
-    private array $filters = [];
+    // phpcs:ignore PSR2.Classes.PropertyDeclaration
+    public bool $identifierOnly { get => $this->filters === [self::IDENTIFIER_ONLY]; }
+
+    /**
+     * @param list<string> $filters
+     * @param array<mixed>|scalar|null $condition
+     */
+    public function __construct(
+        public private(set) readonly array $filters = [],
+        string|null $name = null,
+        array|int|float|string|bool|null $condition = [],
+    ) {
+        parent::__construct($name, $condition);
+    }
 
     public static function by(string ...$names): static
     {
-        $collection = new static();
-        $collection->filters = array_values($names);
-
-        return $collection;
-    }
-
-    /** @return list<string> */
-    public function getFilters(): array
-    {
-        return $this->filters;
-    }
-
-    public function isIdentifierOnly(): bool
-    {
-        return $this->filters === [self::IDENTIFIER_ONLY];
+        return new static(filters: array_values($names));
     }
 
     /** @param array<int, mixed> $children */

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -10,26 +10,25 @@ use function is_string;
 
 final class Typed extends Collection
 {
-    private string $type = '';
+    /** @param array<mixed>|scalar|null $condition */
+    public function __construct(
+        public private(set) readonly string $type = '',
+        string|null $name = null,
+        array|int|float|string|bool|null $condition = [],
+    ) {
+        parent::__construct($name, $condition);
+    }
 
     public static function by(string $type): static
     {
-        $collection = new static();
-        $collection->type = $type;
-
-        return $collection;
-    }
-
-    public function getType(): string
-    {
-        return $this->type;
+        return new static(type: $type);
     }
 
     public function resolveEntityName(EntityFactory $factory, object $row): string
     {
         $name = $factory->get($row, $this->type);
 
-        return is_string($name) ? $name : ($this->getName() ?? '');
+        return is_string($name) ? $name : ($this->name ?? '');
     }
 
     /** @param array<int, mixed> $children */

--- a/src/NotPersistable.php
+++ b/src/NotPersistable.php
@@ -8,6 +8,6 @@ use Attribute;
 
 /** Marks a property as excluded from persistence operations */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class NotPersistable
+final readonly class NotPersistable
 {
 }

--- a/src/Styles/CakePHP.php
+++ b/src/Styles/CakePHP.php
@@ -15,10 +15,8 @@ final class CakePHP extends Standard
 {
     public function realName(string $name): string
     {
-        $name       = $this->camelCaseToSeparator($name, '_');
-        $name       = strtolower($name);
-        $pieces     = explode('_', $name);
-        $pieces[]   = $this->singularToPlural(array_pop($pieces));
+        $pieces = explode('_', strtolower($this->camelCaseToSeparator($name, '_')));
+        $pieces[] = $this->singularToPlural(array_pop($pieces));
 
         return implode('_', $pieces);
     }
@@ -30,28 +28,22 @@ final class CakePHP extends Standard
 
     public function remoteFromIdentifier(string $name): string|null
     {
-        if ($this->isRemoteIdentifier($name)) {
-            return $this->singularToPlural(substr($name, 0, -3));
-        }
-
-        return null;
+        return $this->isRemoteIdentifier($name) ? $this->singularToPlural(substr($name, 0, -3)) : null;
     }
 
     public function styledName(string $name): string
     {
-        $pieces     = explode('_', $name);
-        $pieces[]   = $this->pluralToSingular(array_pop($pieces));
-        $name       = $this->separatorToCamelCase(implode('_', $pieces), '_');
+        $pieces = explode('_', $name);
+        $pieces[] = $this->pluralToSingular(array_pop($pieces));
 
-        return ucfirst($name);
+        return ucfirst($this->separatorToCamelCase(implode('_', $pieces), '_'));
     }
 
     public function composed(string $left, string $right): string
     {
-        $pieces     = explode('_', $right);
-        $pieces[]   = $this->singularToPlural(array_pop($pieces));
-        $right      = implode('_', $pieces);
+        $pieces = explode('_', $right);
+        $pieces[] = $this->singularToPlural(array_pop($pieces));
 
-        return $left . '_' . $right;
+        return $left . '_' . implode('_', $pieces);
     }
 }

--- a/src/Styles/NorthWind.php
+++ b/src/Styles/NorthWind.php
@@ -22,9 +22,7 @@ final class NorthWind extends Standard
 
     public function composed(string $left, string $right): string
     {
-        $left = $this->pluralToSingular($left);
-
-        return $left . $right;
+        return $this->pluralToSingular($left) . $right;
     }
 
     public function identifier(string $name): string
@@ -44,10 +42,6 @@ final class NorthWind extends Standard
 
     public function remoteFromIdentifier(string $name): string|null
     {
-        if ($this->isRemoteIdentifier($name)) {
-            return $this->singularToPlural(substr($name, 0, -2));
-        }
-
-        return null;
+        return $this->isRemoteIdentifier($name) ? $this->singularToPlural(substr($name, 0, -2)) : null;
     }
 }

--- a/src/Styles/Plural.php
+++ b/src/Styles/Plural.php
@@ -30,34 +30,26 @@ final class Plural extends Standard
 
     public function remoteFromIdentifier(string $name): string|null
     {
-        if ($this->isRemoteIdentifier($name)) {
-            return $this->singularToPlural(substr($name, 0, -3));
-        }
-
-        return null;
+        return $this->isRemoteIdentifier($name) ? $this->singularToPlural(substr($name, 0, -3)) : null;
     }
 
     public function realName(string $name): string
     {
-        $name    = strtolower($this->camelCaseToSeparator($name, '_'));
-        $pieces  = array_map($this->singularToPlural(...), explode('_', $name));
-
-        return implode('_', $pieces);
+        return implode('_', array_map(
+            $this->singularToPlural(...),
+            explode('_', strtolower($this->camelCaseToSeparator($name, '_'))),
+        ));
     }
 
     public function styledName(string $name): string
     {
-        $pieces  = array_map($this->pluralToSingular(...), explode('_', $name));
-        $name    = $this->separatorToCamelCase(implode('_', $pieces), '_');
+        $pieces = array_map($this->pluralToSingular(...), explode('_', $name));
 
-        return ucfirst($name);
+        return ucfirst($this->separatorToCamelCase(implode('_', $pieces), '_'));
     }
 
     public function composed(string $left, string $right): string
     {
-        $left  = $this->singularToPlural($left);
-        $right = $this->singularToPlural($right);
-
-        return $left . '_' . $right;
+        return $this->singularToPlural($left) . '_' . $this->singularToPlural($right);
     }
 }

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -19,9 +19,7 @@ class Standard extends AbstractStyle
 
     public function realName(string $name): string
     {
-        $name = $this->camelCaseToSeparator($name, '_');
-
-        return strtolower($name);
+        return strtolower($this->camelCaseToSeparator($name, '_'));
     }
 
     public function realProperty(string $name): string
@@ -31,9 +29,7 @@ class Standard extends AbstractStyle
 
     public function styledName(string $name): string
     {
-        $name = $this->separatorToCamelCase($name, '_');
-
-        return ucfirst($name);
+        return ucfirst($this->separatorToCamelCase($name, '_'));
     }
 
     public function identifier(string $name): string
@@ -58,10 +54,6 @@ class Standard extends AbstractStyle
 
     public function remoteFromIdentifier(string $name): string|null
     {
-        if ($this->isRemoteIdentifier($name)) {
-            return substr($name, 0, -3);
-        }
-
-        return null;
+        return $this->isRemoteIdentifier($name) ? substr($name, 0, -3) : null;
     }
 }

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -46,12 +46,7 @@ class AbstractMapperTest extends TestCase
         $coll = Collection::foo();
         $this->mapper->registerCollection('my_alias', $coll);
 
-        $ref = new ReflectionObject($this->mapper);
-        $prop = $ref->getProperty('collections');
-        /** @var array<string, Collection> $collections */
-        $collections = $prop->getValue($this->mapper);
-        $this->assertContains($coll, $collections);
-
+        $this->assertTrue(isset($this->mapper->my_alias));
         $this->assertEquals($coll, $this->mapper->my_alias);
     }
 
@@ -61,11 +56,7 @@ class AbstractMapperTest extends TestCase
         $coll = Collection::foo();
         $this->mapper->my_alias = $coll;
 
-        $ref = new ReflectionObject($this->mapper);
-        $prop = $ref->getProperty('collections');
-        /** @var array<string, Collection> $collections */
-        $collections = $prop->getValue($this->mapper);
-        $this->assertContains($coll, $collections);
+        $this->assertTrue(isset($this->mapper->my_alias));
 
         $this->assertEquals($coll, $this->mapper->my_alias);
     }
@@ -75,7 +66,7 @@ class AbstractMapperTest extends TestCase
     {
         $collection = $this->mapper->foo()->bar()->baz();
         $expected = Collection::foo();
-        $expected->setMapper($this->mapper);
+        $expected->mapper = $this->mapper;
         $this->assertEquals($expected->bar->baz, $collection);
     }
 
@@ -84,22 +75,22 @@ class AbstractMapperTest extends TestCase
     {
         $collection = $this->mapper->foo->bar->baz;
         $expected = Collection::foo();
-        $expected->setMapper($this->mapper);
+        $expected->mapper = $this->mapper;
         $this->assertEquals($expected->bar->baz, $collection);
     }
 
     #[Test]
     public function getStyleShouldReturnDefaultStandard(): void
     {
-        $style = $this->mapper->getStyle();
+        $style = $this->mapper->style;
         $this->assertInstanceOf(Standard::class, $style);
     }
 
     #[Test]
     public function getStyleShouldReturnSameInstanceOnSubsequentCalls(): void
     {
-        $style1 = $this->mapper->getStyle();
-        $style2 = $this->mapper->getStyle();
+        $style1 = $this->mapper->style;
+        $style2 = $this->mapper->style;
         $this->assertSame($style1, $style2);
     }
 
@@ -123,7 +114,7 @@ class AbstractMapperTest extends TestCase
                 return [];
             }
         };
-        $this->assertSame($style, $mapper->getStyle());
+        $this->assertSame($style, $mapper->style);
     }
 
     #[Test]
@@ -225,7 +216,7 @@ class AbstractMapperTest extends TestCase
     {
         $coll = $this->mapper->unregistered;
         $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertEquals('unregistered', $coll->getName());
+        $this->assertEquals('unregistered', $coll->name);
     }
 
     #[Test]

--- a/tests/CollectionIteratorTest.php
+++ b/tests/CollectionIteratorTest.php
@@ -76,7 +76,7 @@ class CollectionIteratorTest extends TestCase
     public function getChildrenUseCollectionChildren(): void
     {
         $coll = Collection::foo(Collection::bar(), Collection::baz());
-        [$fooChild, $barChild] = $coll->getChildren();
+        [$fooChild, $barChild] = $coll->children;
         $items = iterator_to_array(CollectionIterator::recursive($coll));
         $this->assertContains($fooChild, $items);
         $this->assertContains($barChild, $items);

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -7,7 +7,6 @@ namespace Respect\Data\Collections;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use ReflectionObject;
 use Respect\Data\AbstractMapper;
 use RuntimeException;
 use stdClass;
@@ -32,8 +31,8 @@ class CollectionTest extends TestCase
         $children2 = Collection::baz();
         $coll = Collection::foo($children1, $children2);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
-        $this->assertTrue($coll->hasChildren());
-        $this->assertEquals(2, count($coll->getChildren()));
+        $this->assertTrue($coll->hasChildren);
+        $this->assertEquals(2, count($coll->children));
     }
 
     #[Test]
@@ -41,7 +40,7 @@ class CollectionTest extends TestCase
     {
         $coll = Collection::fooBar(42);
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
-        $this->assertEquals(42, $coll->getCondition());
+        $this->assertEquals(42, $coll->condition);
     }
 
     #[Test]
@@ -51,7 +50,7 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
         $this->assertEquals(
             'Other dominant condition!!!',
-            $coll->getCondition(),
+            $coll->condition,
         );
     }
 
@@ -59,22 +58,19 @@ class CollectionTest extends TestCase
     public function objectConstructorShouldSetObjectAttributes(): void
     {
         $coll = new Collection('some_irrelevant_name');
-        $ref = new ReflectionObject($coll);
-        $prop = $ref->getProperty('last');
-        $this->assertSame($coll, $prop->getValue($coll), 'Constructing it manually should set last item as self');
         $this->assertEquals(
             [],
-            $coll->getCondition(),
+            $coll->condition,
             'Default condition should be an empty array',
         );
-        $this->assertEquals('some_irrelevant_name', $coll->getName());
+        $this->assertEquals('some_irrelevant_name', $coll->name);
     }
 
     #[Test]
     public function objectConstructorWithConditionShouldSetIt(): void
     {
         $coll = new Collection('some_irrelevant_name', 123);
-        $this->assertEquals(123, $coll->getCondition());
+        $this->assertEquals(123, $coll->condition);
     }
 
     #[Test]
@@ -84,7 +80,7 @@ class CollectionTest extends TestCase
         $coll->someTest;
         $this->assertEquals(
             'someTest',
-            $coll->getNext()?->getName(),
+            $coll->next?->name,
             'First time should change next item',
         );
     }
@@ -96,13 +92,13 @@ class CollectionTest extends TestCase
         $coll->someTest;
         $this->assertEquals(
             'someTest',
-            $coll->getNext()?->getName(),
+            $coll->next?->name,
             'First time should change next item',
         );
         $coll->anotherTest;
         $this->assertEquals(
             'someTest',
-            $coll->getNext()?->getName(),
+            $coll->next?->name,
             'The next item on a chain should never be changed after first time',
         );
     }
@@ -111,11 +107,11 @@ class CollectionTest extends TestCase
     public function settingConditionViaDynamicOffsetShouldUseLastNode(): void
     {
         $foo = Collection::foo()->bar->baz[42];
-        $bar = $foo->getNext();
-        $baz = $bar->getNext();
-        $this->assertEmpty($foo->getCondition());
-        $this->assertEmpty($bar->getCondition());
-        $this->assertEquals(42, $baz->getCondition());
+        $bar = $foo->next;
+        $baz = $bar->next;
+        $this->assertEmpty($foo->condition);
+        $this->assertEmpty($bar->condition);
+        $this->assertEquals(42, $baz->condition);
     }
 
     #[Test]
@@ -127,9 +123,9 @@ class CollectionTest extends TestCase
             Collection::children(),
             Collection::here(),
         );
-        $next = $coll->getNext();
+        $next = $coll->next;
         $this->assertNotNull($next);
-        $this->assertEquals(3, count($next->getChildren()));
+        $this->assertEquals(3, count($next->children));
     }
 
     #[Test]
@@ -137,25 +133,25 @@ class CollectionTest extends TestCase
     {
         $coll = new Collection('foo_collection');
         $coll->addChild(new Collection('bar_child'));
-        $children = $coll->getChildren();
+        $children = $coll->children;
         $child = reset($children);
         $this->assertInstanceOf(Collection::class, $child);
-        $this->assertEquals(false, $child->isRequired());
-        $this->assertEquals($coll->getName(), $child->getParent()?->getName());
+        $this->assertEquals(false, $child->required);
+        $this->assertEquals($coll->name, $child->parent?->name);
     }
 
     #[Test]
     public function childrenShouldMakeHasMoreTrue(): void
     {
         $coll = Collection::foo(Collection::thisIsAChildren());
-        $this->assertTrue($coll->hasMore());
+        $this->assertTrue($coll->more);
     }
 
     #[Test]
     public function chainingShouldMakeHasMoreTrue(): void
     {
         $coll = Collection::foo()->barChain;
-        $this->assertTrue($coll->hasMore());
+        $this->assertTrue($coll->more);
     }
 
     #[Test]
@@ -187,7 +183,7 @@ class CollectionTest extends TestCase
             ->method('persist')
             ->with($persisted, $collection)
             ->willReturn(true);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->persist($persisted);
     }
 
@@ -201,7 +197,7 @@ class CollectionTest extends TestCase
             ->method('remove')
             ->with($removed, $collection)
             ->willReturn(true);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->remove($removed);
     }
 
@@ -215,7 +211,7 @@ class CollectionTest extends TestCase
             ->method('fetch')
             ->with($collection)
             ->willReturn($result);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->fetch();
     }
 
@@ -230,7 +226,7 @@ class CollectionTest extends TestCase
             ->method('fetch')
             ->with($collection, $extra)
             ->willReturn($result);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->fetch($extra);
     }
 
@@ -243,7 +239,7 @@ class CollectionTest extends TestCase
             ->method('fetchAll')
             ->with($collection)
             ->willReturn([]);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->fetchAll();
     }
 
@@ -257,7 +253,7 @@ class CollectionTest extends TestCase
             ->method('fetchAll')
             ->with($collection, $extra)
             ->willReturn([]);
-        $collection->setMapper($mapperMock);
+        $collection->mapper = $mapperMock;
         $collection->fetchAll($extra);
     }
 
@@ -303,28 +299,28 @@ class CollectionTest extends TestCase
     {
         $coll = Collection::using(42);
         $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertEquals(42, $coll->getCondition());
+        $this->assertEquals(42, $coll->condition);
     }
 
     #[Test]
     public function getParentShouldReturnNullWhenNoParent(): void
     {
         $coll = new Collection('foo');
-        $this->assertNull($coll->getParent());
+        $this->assertNull($coll->parent);
     }
 
     #[Test]
     public function getNextShouldReturnNullWhenNoNext(): void
     {
         $coll = new Collection('foo');
-        $this->assertNull($coll->getNext());
+        $this->assertNull($coll->next);
     }
 
     #[Test]
-    public function hasNextShouldReturnFalseWhenNoNext(): void
+    public function getNextShouldReturnNullWhenNone(): void
     {
         $coll = new Collection('foo');
-        $this->assertFalse($coll->hasNext());
+        $this->assertNull($coll->next);
     }
 
     #[Test]
@@ -336,8 +332,8 @@ class CollectionTest extends TestCase
         $mapperMock->method('__get')->with('bar')->willReturn($registered);
 
         $coll = new Collection('foo');
-        $coll->setMapper($mapperMock);
+        $coll->mapper = $mapperMock;
         $result = $coll->bar;
-        $this->assertEquals('bar', $result->getNext()?->getName());
+        $this->assertEquals('bar', $result->next?->name);
     }
 }

--- a/tests/Collections/CompositeTest.php
+++ b/tests/Collections/CompositeTest.php
@@ -20,13 +20,13 @@ class CompositeTest extends TestCase
         $children2 = Composite::with(['bat' => ['bar']])->baz()->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertInstanceOf(Collection::class, $coll->getNext());
+        $this->assertInstanceOf(Collection::class, $coll->next);
         $this->assertInstanceOf(Composite::class, $children1);
         $this->assertInstanceOf(Composite::class, $children2);
-        $this->assertTrue($coll->hasChildren());
-        $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(['foo' => ['bar']], $children1->getCompositions());
-        $this->assertEquals(['bat' => ['bar']], $children2->getCompositions());
+        $this->assertTrue($coll->hasChildren);
+        $this->assertEquals(2, count($coll->children));
+        $this->assertEquals(['foo' => ['bar']], $children1->compositions);
+        $this->assertEquals(['bat' => ['bar']], $children2->compositions);
     }
 
     #[Test]
@@ -34,7 +34,7 @@ class CompositeTest extends TestCase
     {
         $coll = Composite::items();
         $this->assertInstanceOf(Composite::class, $coll);
-        $this->assertEquals('items', $coll->getName());
-        $this->assertEquals([], $coll->getCompositions());
+        $this->assertEquals('items', $coll->name);
+        $this->assertEquals([], $coll->compositions);
     }
 }

--- a/tests/Collections/FilteredTest.php
+++ b/tests/Collections/FilteredTest.php
@@ -20,13 +20,13 @@ class FilteredTest extends TestCase
         $children2 = Filtered::by('bat')->baz()->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertInstanceOf(Collection::class, $coll->getNext());
+        $this->assertInstanceOf(Collection::class, $coll->next);
         $this->assertInstanceOf(Filtered::class, $children1);
         $this->assertInstanceOf(Filtered::class, $children2);
-        $this->assertTrue($coll->hasChildren());
-        $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals(['bar'], $children1->getFilters());
-        $this->assertEquals(['bat'], $children2->getFilters());
+        $this->assertTrue($coll->hasChildren);
+        $this->assertEquals(2, count($coll->children));
+        $this->assertEquals(['bar'], $children1->filters);
+        $this->assertEquals(['bat'], $children2->filters);
     }
 
     #[Test]
@@ -34,28 +34,28 @@ class FilteredTest extends TestCase
     {
         $coll = Filtered::items();
         $this->assertInstanceOf(Filtered::class, $coll);
-        $this->assertEquals('items', $coll->getName());
-        $this->assertEquals([], $coll->getFilters());
+        $this->assertEquals('items', $coll->name);
+        $this->assertEquals([], $coll->filters);
     }
 
     #[Test]
     public function isIdentifierOnlyReturnsTrueForIdentifierOnlyFilter(): void
     {
         $coll = Filtered::by(Filtered::IDENTIFIER_ONLY)->post();
-        $this->assertTrue($coll->isIdentifierOnly());
+        $this->assertTrue($coll->identifierOnly);
     }
 
     #[Test]
     public function isIdentifierOnlyReturnsFalseForNamedFilters(): void
     {
         $coll = Filtered::by('title')->post();
-        $this->assertFalse($coll->isIdentifierOnly());
+        $this->assertFalse($coll->identifierOnly);
     }
 
     #[Test]
     public function isIdentifierOnlyReturnsFalseForEmptyFilters(): void
     {
         $coll = Filtered::post();
-        $this->assertFalse($coll->isIdentifierOnly());
+        $this->assertFalse($coll->identifierOnly);
     }
 }

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -22,13 +22,13 @@ class TypedTest extends TestCase
         $children2 = Typed::by('b')->baz()->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertInstanceOf(Collection::class, $coll->getNext());
+        $this->assertInstanceOf(Collection::class, $coll->next);
         $this->assertInstanceOf(Typed::class, $children1);
         $this->assertInstanceOf(Typed::class, $children2);
-        $this->assertTrue($coll->hasChildren());
-        $this->assertEquals(2, count($coll->getChildren()));
-        $this->assertEquals('a', $children1->getType());
-        $this->assertEquals('b', $children2->getType());
+        $this->assertTrue($coll->hasChildren);
+        $this->assertEquals(2, count($coll->children));
+        $this->assertEquals('a', $children1->type);
+        $this->assertEquals('b', $children2->type);
     }
 
     #[Test]
@@ -36,8 +36,8 @@ class TypedTest extends TestCase
     {
         $coll = Typed::items();
         $this->assertInstanceOf(Typed::class, $coll);
-        $this->assertEquals('items', $coll->getName());
-        $this->assertEquals('', $coll->getType());
+        $this->assertEquals('items', $coll->name);
+        $this->assertEquals('', $coll->type);
     }
 
     #[Test]

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -10,7 +10,6 @@ use stdClass;
 
 use function array_filter;
 use function array_values;
-use function assert;
 use function is_array;
 use function reset;
 
@@ -29,8 +28,8 @@ final class InMemoryMapper extends AbstractMapper
 
     public function fetch(Collection $collection, mixed $extra = null): mixed
     {
-        $name = (string) $collection->getName();
-        $row = $this->findRow($name, $collection->getCondition());
+        $name = (string) $collection->name;
+        $row = $this->findRow($name, $collection->condition);
 
         if ($row === null) {
             return false;
@@ -44,7 +43,7 @@ final class InMemoryMapper extends AbstractMapper
             $this->entityFactory->set($entity, $key, $value);
         }
 
-        if ($collection->hasMore()) {
+        if ($collection->more) {
             /** @var SplObjectStorage<object, Collection> $entities */
             $entities = new SplObjectStorage();
             $entities[$entity] = $collection;
@@ -60,8 +59,8 @@ final class InMemoryMapper extends AbstractMapper
     /** @return array<int, mixed> */
     public function fetchAll(Collection $collection, mixed $extra = null): array
     {
-        $name = (string) $collection->getName();
-        $rows = $this->findRows($name, $collection->getCondition());
+        $name = (string) $collection->name;
+        $rows = $this->findRows($name, $collection->condition);
         $result = [];
 
         foreach ($rows as $row) {
@@ -73,7 +72,7 @@ final class InMemoryMapper extends AbstractMapper
                 $this->entityFactory->set($entity, $key, $value);
             }
 
-            if ($collection->hasMore()) {
+            if ($collection->more) {
                 /** @var SplObjectStorage<object, Collection> $entities */
                 $entities = new SplObjectStorage();
                 $entities[$entity] = $collection;
@@ -92,9 +91,8 @@ final class InMemoryMapper extends AbstractMapper
     {
         foreach ($this->new as $entity) {
             $collection = $this->tracked[$entity];
-            assert($collection instanceof Collection);
-            $tableName = (string) $collection->getName();
-            $pk = $this->getStyle()->identifier($tableName);
+            $tableName = (string) $collection->name;
+            $pk = $this->style->identifier($tableName);
             $row = $this->entityFactory->extractProperties($entity);
 
             if (!isset($row[$pk])) {
@@ -116,9 +114,8 @@ final class InMemoryMapper extends AbstractMapper
             }
 
             $collection = $this->tracked[$entity];
-            assert($collection instanceof Collection);
-            $tableName = (string) $collection->getName();
-            $pk = $this->getStyle()->identifier($tableName);
+            $tableName = (string) $collection->name;
+            $pk = $this->style->identifier($tableName);
             $pkValue = $this->entityFactory->get($entity, $pk);
             $row = $this->entityFactory->extractProperties($entity);
 
@@ -133,9 +130,8 @@ final class InMemoryMapper extends AbstractMapper
 
         foreach ($this->removed as $entity) {
             $collection = $this->tracked[$entity];
-            assert($collection instanceof Collection);
-            $tableName = (string) $collection->getName();
-            $pk = $this->getStyle()->identifier($tableName);
+            $tableName = (string) $collection->name;
+            $pk = $this->style->identifier($tableName);
             $pkValue = $this->entityFactory->get($entity, $pk);
 
             $rows = $this->tables[$tableName];
@@ -157,13 +153,13 @@ final class InMemoryMapper extends AbstractMapper
     /** @param SplObjectStorage<object, Collection> $entities */
     private function fetchRelated(object $parent, Collection $collection, SplObjectStorage $entities): void
     {
-        $next = $collection->getNext();
+        $next = $collection->next;
 
         if ($next !== null) {
             $this->fetchRelatedCollection($parent, $next, $entities);
         }
 
-        foreach ($collection->getChildren() as $child) {
+        foreach ($collection->children as $child) {
             $this->fetchRelatedCollection($parent, $child, $entities);
         }
     }
@@ -174,15 +170,15 @@ final class InMemoryMapper extends AbstractMapper
         Collection $related,
         SplObjectStorage $entities,
     ): void {
-        $relatedName = (string) $related->getName();
-        $fkCol = $this->getStyle()->remoteIdentifier($relatedName);
+        $relatedName = (string) $related->name;
+        $fkCol = $this->style->remoteIdentifier($relatedName);
         $fkValue = $this->entityFactory->get($parent, $fkCol);
 
         if ($fkValue === null) {
             return;
         }
 
-        $pk = $this->getStyle()->identifier($relatedName);
+        $pk = $this->style->identifier($relatedName);
         $row = $this->findRowByPk($relatedName, $pk, $fkValue);
 
         if ($row === null) {
@@ -200,7 +196,7 @@ final class InMemoryMapper extends AbstractMapper
         $entities[$childEntity] = $related;
         $this->markTracked($childEntity, $related);
 
-        if (!$related->hasMore()) {
+        if (!$related->more) {
             return;
         }
 
@@ -224,7 +220,7 @@ final class InMemoryMapper extends AbstractMapper
             return $rows;
         }
 
-        $pk = $this->getStyle()->identifier($table);
+        $pk = $this->style->identifier($table);
         $pkValue = is_array($condition) ? reset($condition) : $condition;
 
         return array_values(array_filter(


### PR DESCRIPTION
- Replace trivial getters/setters with asymmetric visibility (public
  private(set)) on Collection, Filtered, Typed, Composite properties
- Add virtual property hooks: Collection::$hasChildren, $more,
  Filtered::$identifierOnly, AbstractMapper::$style
- Use constructor promotion with readonly for Typed::$type,
  Composite::$compositions, Filtered::$filters
- Make NotPersistable a final readonly class
- Cache tail node in Collection::$last for O(1) chain stacking
- Tighten visibility: AbstractMapper::$collections and tryHydration()
  to private, Collection::findMapper()/resolveMapper() to private
- Remove all trivial getters (getName, getCondition, getNext, getParent,
  getChildren, isRequired, getFilters, getType, getCompositions),
  setters (setMapper, setCondition, setParent, setRequired), and boolean
  methods (hasChildren, hasMore, isIdentifierOnly, getStyle)
- Inline single-use variables and convert verbose conditionals to
  ternaries across Style classes
- Exclude PSR2.Classes.PropertyDeclaration from PHPCS (4.0.x cannot
  parse property hooks)
- Update all callers in src and tests to use direct property access