### PR TITLE
Introduce Hydrators

### DIFF
--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;
-use Respect\Data\Collections\Composite;
 use Respect\Data\Collections\Filtered;
 use SplObjectStorage;
-
-use function count;
 
 abstract class AbstractMapper
 {
@@ -106,6 +103,13 @@ abstract class AbstractMapper
         $this->collections[$alias] = $collection;
     }
 
+    abstract protected function defaultHydrator(Collection $collection): Hydrator;
+
+    protected function resolveHydrator(Collection $collection): Hydrator
+    {
+        return $collection->hydrator ?? $this->defaultHydrator($collection);
+    }
+
     /** @param SplObjectStorage<object, Collection> $entities */
     protected function postHydrate(SplObjectStorage $entities): void
     {
@@ -124,42 +128,6 @@ abstract class AbstractMapper
                 $this->entityFactory->set($instance, $field, $v);
             }
         }
-    }
-
-    /**
-     * @param SplObjectStorage<object, Collection> $entities
-     *
-     * @return array<int, object>
-     */
-    protected function buildEntitiesInstances(
-        Collection $collection,
-        SplObjectStorage $entities,
-    ): array {
-        $entitiesInstances = [];
-
-        foreach (CollectionIterator::recursive($collection) as $c) {
-            if (!$c instanceof Collection) {
-                continue;
-            }
-
-            if ($c instanceof Filtered && !$c->filters) {
-                continue;
-            }
-
-            $entityInstance = $this->entityFactory->createByName((string) $c->name);
-
-            if ($c instanceof Composite) {
-                $compositionCount = count($c->compositions);
-                for ($i = 0; $i < $compositionCount; $i++) {
-                    $entitiesInstances[] = $entityInstance;
-                }
-            }
-
-            $entities[$entityInstance] = $c;
-            $entitiesInstances[] = $entityInstance;
-        }
-
-        return $entitiesInstances;
     }
 
     /** @param SplObjectStorage<object, Collection> $entities */

--- a/src/CollectionIterator.php
+++ b/src/CollectionIterator.php
@@ -8,6 +8,7 @@ use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 use Respect\Data\Collections\Collection;
 
+use function array_filter;
 use function is_array;
 
 /** @extends RecursiveArrayIterator<array-key, Collection> */
@@ -29,7 +30,7 @@ final class CollectionIterator extends RecursiveArrayIterator
         parent::__construct($items);
     }
 
-    /** @return RecursiveIteratorIterator<CollectionIterator> */
+    /** @return RecursiveIteratorIterator<CollectionIterator>&iterable<string, Collection> */
     public static function recursive(Collection $target): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(new self($target), 1);
@@ -61,6 +62,9 @@ final class CollectionIterator extends RecursiveArrayIterator
             $pool[] = $c->next;
         }
 
-        return new static($pool, $this->namesCounts);
+        return new static(
+            array_filter($pool, static fn(Collection $c): bool => $c->name !== null),
+            $this->namesCounts,
+        );
     }
 }

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -7,6 +7,7 @@ namespace Respect\Data\Collections;
 use ArrayAccess;
 use Respect\Data\AbstractMapper;
 use Respect\Data\EntityFactory;
+use Respect\Data\Hydrator;
 use RuntimeException;
 
 use function is_array;
@@ -18,6 +19,8 @@ class Collection implements ArrayAccess
     public private(set) bool $required = true;
 
     public AbstractMapper|null $mapper = null;
+
+    public Hydrator|null $hydrator = null;
 
     public private(set) Collection|null $parent = null;
 
@@ -99,6 +102,13 @@ class Collection implements ArrayAccess
     public function offsetUnset(mixed $offset): void
     {
         // no-op
+    }
+
+    public function hydrateFrom(Hydrator $hydrator): static
+    {
+        $this->hydrator = $hydrator;
+
+        return $this;
     }
 
     public function stack(Collection $collection): static

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data;
+
+use Respect\Data\Collections\Collection;
+use SplObjectStorage;
+
+/** Transforms raw backend data into entity instances mapped to their collections */
+interface Hydrator
+{
+    /** @return SplObjectStorage<object, Collection>|false */
+    public function hydrate(
+        mixed $raw,
+        Collection $collection,
+        EntityFactory $entityFactory,
+    ): SplObjectStorage|false;
+}

--- a/src/Hydrators/Flat.php
+++ b/src/Hydrators/Flat.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data\Hydrators;
+
+use Respect\Data\CollectionIterator;
+use Respect\Data\Collections\Collection;
+use Respect\Data\Collections\Composite;
+use Respect\Data\Collections\Filtered;
+use Respect\Data\EntityFactory;
+use Respect\Data\Hydrator;
+use Respect\Data\Styles\Stylable;
+use SplObjectStorage;
+
+use function array_pop;
+use function array_reverse;
+use function count;
+use function is_array;
+
+/**
+ * Decomposes a flat row into multiple entity instances using PK boundaries.
+ *
+ * Subclasses define how column names are resolved from the raw data format.
+ */
+abstract class Flat implements Hydrator
+{
+    public function __construct(
+        private readonly Stylable $style,
+    ) {
+    }
+
+    /** @return SplObjectStorage<object, Collection>|false */
+    public function hydrate(
+        mixed $raw,
+        Collection $collection,
+        EntityFactory $entityFactory,
+    ): SplObjectStorage|false {
+        if (!$raw || !is_array($raw)) {
+            return false;
+        }
+
+        /** @var SplObjectStorage<object, Collection> $entities */
+        $entities = new SplObjectStorage();
+        $entitiesInstances = $this->buildEntitiesInstances($collection, $entities, $entityFactory);
+
+        if (!$entitiesInstances) {
+            return false;
+        }
+
+        $entityInstance = array_pop($entitiesInstances);
+
+        foreach (array_reverse($raw, true) as $col => $value) {
+            $columnName = $this->resolveColumnName($col, $raw);
+            $primaryName = $this->style->identifier(
+                (string) $entities[$entityInstance]->name,
+            );
+
+            /** @phpstan-ignore argument.type */
+            $entityFactory->set($entityInstance, $columnName, $value);
+
+            if ($primaryName != $columnName) {
+                continue;
+            }
+
+            $entityInstance = array_pop($entitiesInstances);
+        }
+
+        return $this->resolveTypedEntities($entities, $entityFactory);
+    }
+
+    /** Resolve the column name for a given reference (numeric index, namespaced key, etc.) */
+    abstract protected function resolveColumnName(mixed $reference, mixed $raw): string;
+
+    /**
+     * @param SplObjectStorage<object, Collection> $entities
+     *
+     * @return SplObjectStorage<object, Collection>
+     */
+    private function resolveTypedEntities(
+        SplObjectStorage $entities,
+        EntityFactory $entityFactory,
+    ): SplObjectStorage {
+        /** @var SplObjectStorage<object, Collection> $resolved */
+        $resolved = new SplObjectStorage();
+
+        foreach ($entities as $entity) {
+            $coll = $entities[$entity];
+            $entityName = $coll->resolveEntityName($entityFactory, $entity);
+            $defaultName = (string) $coll->name;
+
+            if ($entityName === $defaultName) {
+                $resolved[$entity] = $coll;
+
+                continue;
+            }
+
+            $resolved[$entityFactory->hydrate($entity, $entityName)] = $coll;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param SplObjectStorage<object, Collection> $entities
+     *
+     * @return array<int, object>
+     */
+    private function buildEntitiesInstances(
+        Collection $collection,
+        SplObjectStorage $entities,
+        EntityFactory $entityFactory,
+    ): array {
+        $entitiesInstances = [];
+
+        foreach (CollectionIterator::recursive($collection) as $c) {
+            if ($c->name === null || ($c instanceof Filtered && !$c->filters)) {
+                continue;
+            }
+
+            $entityInstance = $entityFactory->createByName($c->name);
+
+            if ($c instanceof Composite) {
+                $compositionCount = count($c->compositions);
+                for ($i = 0; $i < $compositionCount; $i++) {
+                    $entitiesInstances[] = $entityInstance;
+                }
+            }
+
+            $entities[$entityInstance] = $c;
+            $entitiesInstances[] = $entityInstance;
+        }
+
+        return $entitiesInstances;
+    }
+}

--- a/src/Hydrators/Nested.php
+++ b/src/Hydrators/Nested.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data\Hydrators;
+
+use Respect\Data\Collections\Collection;
+use Respect\Data\EntityFactory;
+use Respect\Data\Hydrator;
+use SplObjectStorage;
+
+use function get_object_vars;
+use function is_object;
+
+/** Hydrates entities from a nested structure (object with sub-objects keyed by collection name) */
+final class Nested implements Hydrator
+{
+    /** @return SplObjectStorage<object, Collection>|false */
+    public function hydrate(
+        mixed $raw,
+        Collection $collection,
+        EntityFactory $entityFactory,
+    ): SplObjectStorage|false {
+        if (!is_object($raw)) {
+            return false;
+        }
+
+        /** @var SplObjectStorage<object, Collection> $entities */
+        $entities = new SplObjectStorage();
+        $entity = $entityFactory->hydrate($raw, $collection->resolveEntityName($entityFactory, $raw));
+        $entities[$entity] = $collection;
+
+        $this->hydrateRelated($raw, $collection, $entityFactory, $entities);
+
+        return $entities;
+    }
+
+    /** @param SplObjectStorage<object, Collection> $entities */
+    private function hydrateRelated(
+        object $raw,
+        Collection $collection,
+        EntityFactory $entityFactory,
+        SplObjectStorage $entities,
+    ): void {
+        if ($collection->next !== null) {
+            $this->hydrateChild($raw, $collection->next, $entityFactory, $entities);
+        }
+
+        foreach ($collection->children as $child) {
+            $this->hydrateChild($raw, $child, $entityFactory, $entities);
+        }
+    }
+
+    /** @param SplObjectStorage<object, Collection> $entities */
+    private function hydrateChild(
+        object $parentRaw,
+        Collection $child,
+        EntityFactory $entityFactory,
+        SplObjectStorage $entities,
+    ): void {
+        $key = $child->name;
+        if ($key === null) {
+            return;
+        }
+
+        $vars = get_object_vars($parentRaw);
+        if (!isset($vars[$key]) || !is_object($vars[$key])) {
+            return;
+        }
+
+        $childRaw = $vars[$key];
+        $entity = $entityFactory->hydrate($childRaw, $child->resolveEntityName($entityFactory, $childRaw));
+        $entities[$entity] = $child;
+
+        $this->hydrateRelated($childRaw, $child, $entityFactory, $entities);
+    }
+}

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Respect\Data\Collections\Collection;
 use Respect\Data\Collections\Filtered;
+use Respect\Data\Hydrators\Nested;
 use Respect\Data\Styles\CakePHP;
 use Respect\Data\Styles\Standard;
 use SplObjectStorage;
@@ -36,6 +37,11 @@ class AbstractMapperTest extends TestCase
             public function fetchAll(Collection $collection, mixed $extra = null): array
             {
                 return [];
+            }
+
+            protected function defaultHydrator(Collection $collection): Hydrator
+            {
+                return new Nested();
             }
         };
     }
@@ -112,6 +118,11 @@ class AbstractMapperTest extends TestCase
             public function fetchAll(Collection $collection, mixed $extra = null): array
             {
                 return [];
+            }
+
+            protected function defaultHydrator(Collection $collection): Hydrator
+            {
+                return new Nested();
             }
         };
         $this->assertSame($style, $mapper->style);

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Respect\Data\AbstractMapper;
+use Respect\Data\EntityFactory;
+use Respect\Data\Hydrators\Nested;
 use RuntimeException;
 use stdClass;
 
@@ -335,5 +337,29 @@ class CollectionTest extends TestCase
         $coll->mapper = $mapperMock;
         $result = $coll->bar;
         $this->assertEquals('bar', $result->next?->name);
+    }
+
+    #[Test]
+    public function hydrateFromSetsHydrator(): void
+    {
+        $hydrator = new Nested();
+        $coll = Collection::foo()->hydrateFrom($hydrator);
+        $this->assertSame($hydrator, $coll->hydrator);
+    }
+
+    #[Test]
+    public function resolveEntityNameReturnsCollectionName(): void
+    {
+        $coll = Collection::author();
+        $factory = new EntityFactory();
+        $this->assertEquals('author', $coll->resolveEntityName($factory, new stdClass()));
+    }
+
+    #[Test]
+    public function resolveEntityNameReturnsEmptyForNullName(): void
+    {
+        $coll = new Collection();
+        $factory = new EntityFactory();
+        $this->assertEquals('', $coll->resolveEntityName($factory, new stdClass()));
     }
 }

--- a/tests/Hydrators/FlatTest.php
+++ b/tests/Hydrators/FlatTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data\Hydrators;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Respect\Data\Collections\Collection;
+use Respect\Data\Collections\Composite;
+use Respect\Data\Collections\Filtered;
+use Respect\Data\Collections\Typed;
+use Respect\Data\EntityFactory;
+use Respect\Data\Styles\Standard;
+use Respect\Data\Styles\Stylable;
+use stdClass;
+
+#[CoversClass(Flat::class)]
+class FlatTest extends TestCase
+{
+    private EntityFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new EntityFactory();
+    }
+
+    #[Test]
+    public function hydrateReturnsFalseForEmpty(): void
+    {
+        $hydrator = $this->hydrator(['id']);
+
+        $this->assertFalse($hydrator->hydrate(null, Collection::author(), $this->factory));
+        $this->assertFalse($hydrator->hydrate([], Collection::author(), $this->factory));
+        $this->assertFalse($hydrator->hydrate(false, Collection::author(), $this->factory));
+    }
+
+    #[Test]
+    public function hydrateReturnsFalseWhenNoEntitiesBuilt(): void
+    {
+        $hydrator = $this->hydrator([]);
+        $filtered = Filtered::by()->post();
+
+        $this->assertFalse($hydrator->hydrate([1, 'value'], $filtered, $this->factory));
+    }
+
+    #[Test]
+    public function hydrateSingleEntity(): void
+    {
+        $hydrator = $this->hydrator(['id', 'name']);
+        $collection = Collection::author();
+
+        $result = $hydrator->hydrate([1, 'Author'], $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+        $result->rewind();
+        $entity = $result->current();
+        $this->assertEquals(1, $this->factory->get($entity, 'id'));
+        $this->assertEquals('Author', $this->factory->get($entity, 'name'));
+    }
+
+    #[Test]
+    public function hydrateMultipleEntitiesWithPkBoundary(): void
+    {
+        $hydrator = $this->hydrator(['id', 'name', 'author_id', 'id', 'title']);
+        $collection = Collection::author()->post;
+
+        $result = $hydrator->hydrate([1, 'Author', 1, 10, 'Post Title'], $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(2, $result);
+
+        $entities = [];
+        foreach ($result as $entity) {
+            $entities[] = $entity;
+        }
+
+        $this->assertEquals(1, $this->factory->get($entities[0], 'id'));
+        $this->assertEquals('Author', $this->factory->get($entities[0], 'name'));
+        $this->assertEquals(10, $this->factory->get($entities[1], 'id'));
+        $this->assertEquals('Post Title', $this->factory->get($entities[1], 'title'));
+    }
+
+    #[Test]
+    public function hydrateSkipsUnfilteredFilteredCollections(): void
+    {
+        $hydrator = $this->hydrator(['id', 'title']);
+        $filtered = Filtered::by()->post();
+        $collection = Collection::author();
+        $collection->stack($filtered);
+
+        $result = $hydrator->hydrate([1, 'Post Title'], $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function hydrateFilteredCollectionWithFilters(): void
+    {
+        $hydrator = $this->hydrator(['id', 'name', 'id']);
+        $filtered = Filtered::by('name')->author();
+        $collection = Collection::post();
+        $collection->stack($filtered);
+
+        $result = $hydrator->hydrate([1, 'Author', 10], $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(2, $result);
+    }
+
+    #[Test]
+    public function hydrateResolvesTypedEntities(): void
+    {
+        $factory = new EntityFactory(entityNamespace: 'Respect\Data\Hydrators\\');
+        $hydrator = $this->hydrator(['id', 'type', 'title']);
+        $collection = Typed::by('type')->issue();
+
+        $result = $hydrator->hydrate([1, 'stdClass', 'Bug Report'], $collection, $factory);
+
+        $this->assertNotFalse($result);
+        $result->rewind();
+        $this->assertInstanceOf(stdClass::class, $result->current());
+    }
+
+    #[Test]
+    public function hydrateWithComposite(): void
+    {
+        $hydrator = $this->hydrator(['id', 'title', 'id', 'bio']);
+        $composite = Composite::with(['profile' => ['bio']])->author();
+
+        $result = $hydrator->hydrate([1, 'Author', 1, 'A bio'], $composite, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+        $result->rewind();
+        $entity = $result->current();
+        $this->assertEquals('A bio', $this->factory->get($entity, 'bio'));
+    }
+
+    /** @param list<string> $columnNames */
+    private function hydrator(array $columnNames, Stylable $style = new Standard()): Flat
+    {
+        return new class ($columnNames, $style) extends Flat {
+            /** @param list<string> $columnNames */
+            public function __construct(
+                private readonly array $columnNames,
+                Stylable $style,
+            ) {
+                parent::__construct($style);
+            }
+
+            protected function resolveColumnName(mixed $reference, mixed $raw): string
+            {
+                /** @phpstan-ignore offsetAccess.invalidOffset */
+                return $this->columnNames[$reference];
+            }
+        };
+    }
+}

--- a/tests/Hydrators/NestedTest.php
+++ b/tests/Hydrators/NestedTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data\Hydrators;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Respect\Data\Collections\Collection;
+use Respect\Data\Collections\Typed;
+use Respect\Data\EntityFactory;
+use stdClass;
+
+#[CoversClass(Nested::class)]
+class NestedTest extends TestCase
+{
+    private Nested $hydrator;
+
+    private EntityFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->hydrator = new Nested();
+        $this->factory = new EntityFactory();
+    }
+
+    #[Test]
+    public function hydrateReturnsFalseForNonObject(): void
+    {
+        $collection = Collection::author();
+
+        $this->assertFalse($this->hydrator->hydrate(null, $collection, $this->factory));
+        $this->assertFalse($this->hydrator->hydrate(false, $collection, $this->factory));
+        $this->assertFalse($this->hydrator->hydrate('string', $collection, $this->factory));
+    }
+
+    #[Test]
+    public function hydrateSingleEntity(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->name = 'Author Name';
+        $collection = Collection::author();
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+        $result->rewind();
+        $entity = $result->current();
+        $this->assertEquals(1, $this->factory->get($entity, 'id'));
+        $this->assertEquals('Author Name', $this->factory->get($entity, 'name'));
+        $this->assertSame($collection, $result[$entity]);
+    }
+
+    #[Test]
+    public function hydrateWithNestedChild(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->title = 'Post Title';
+        $raw->author = new stdClass();
+        $raw->author->id = 5;
+        $raw->author->name = 'Author';
+
+        $collection = Collection::post()->author;
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(2, $result);
+    }
+
+    #[Test]
+    public function hydrateWithMissingNestedKeyReturnsPartial(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->title = 'Post Title';
+        // no 'author' key
+
+        $collection = Collection::post()->author;
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function hydrateDeeplyNested(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->text = 'Comment';
+        $raw->post = new stdClass();
+        $raw->post->id = 10;
+        $raw->post->title = 'Post';
+        $raw->post->author = new stdClass();
+        $raw->post->author->id = 100;
+        $raw->post->author->name = 'Author';
+
+        $collection = Collection::comment()->post->author;
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function hydrateWithChildren(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->title = 'Post';
+        $raw->author = new stdClass();
+        $raw->author->id = 5;
+        $raw->author->name = 'Author';
+        $raw->category = new stdClass();
+        $raw->category->id = 3;
+        $raw->category->label = 'Tech';
+
+        $collection = Collection::post(Collection::author(), Collection::category());
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(3, $result);
+    }
+
+    #[Test]
+    public function hydrateWithTypedCollection(): void
+    {
+        $factory = new EntityFactory(entityNamespace: 'Respect\Data\Hydrators\\');
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->title = 'Issue';
+        $raw->type = 'stdClass';
+
+        $collection = Typed::by('type')->issue();
+
+        $result = $this->hydrator->hydrate($raw, $collection, $factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function hydrateChildWithNullNameIsSkipped(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+
+        $child = new Collection();
+        $collection = Collection::post($child);
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+    }
+
+    #[Test]
+    public function hydrateScalarNestedValueIsIgnored(): void
+    {
+        $raw = new stdClass();
+        $raw->id = 1;
+        $raw->author = 'not-an-object';
+
+        $collection = Collection::post()->author;
+
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
+
+        $this->assertNotFalse($result);
+        $this->assertCount(1, $result);
+    }
+}

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;
-use SplObjectStorage;
+use Respect\Data\Hydrators\Nested;
 use stdClass;
 
 use function array_filter;
@@ -28,59 +28,23 @@ final class InMemoryMapper extends AbstractMapper
 
     public function fetch(Collection $collection, mixed $extra = null): mixed
     {
-        $name = (string) $collection->name;
-        $row = $this->findRow($name, $collection->condition);
+        $row = $this->findRow((string) $collection->name, $collection->condition);
 
-        if ($row === null) {
-            return false;
-        }
-
-        $rowObject = $this->rowToObject($row);
-        $entityName = $collection->resolveEntityName($this->entityFactory, $rowObject);
-        $entity = $this->entityFactory->createByName($entityName);
-
-        foreach ($row as $key => $value) {
-            $this->entityFactory->set($entity, $key, $value);
-        }
-
-        if ($collection->more) {
-            /** @var SplObjectStorage<object, Collection> $entities */
-            $entities = new SplObjectStorage();
-            $entities[$entity] = $collection;
-            $this->fetchRelated($entity, $collection, $entities);
-            $this->postHydrate($entities);
-        }
-
-        $this->markTracked($entity, $collection);
-
-        return $entity;
+        return $row !== null ? $this->hydrateRow($row, $collection) : false;
     }
 
     /** @return array<int, mixed> */
     public function fetchAll(Collection $collection, mixed $extra = null): array
     {
-        $name = (string) $collection->name;
-        $rows = $this->findRows($name, $collection->condition);
+        $rows = $this->findRows((string) $collection->name, $collection->condition);
         $result = [];
 
         foreach ($rows as $row) {
-            $rowObject = $this->rowToObject($row);
-            $entityName = $collection->resolveEntityName($this->entityFactory, $rowObject);
-            $entity = $this->entityFactory->createByName($entityName);
-
-            foreach ($row as $key => $value) {
-                $this->entityFactory->set($entity, $key, $value);
+            $entity = $this->hydrateRow($row, $collection);
+            if ($entity === false) {
+                continue;
             }
 
-            if ($collection->more) {
-                /** @var SplObjectStorage<object, Collection> $entities */
-                $entities = new SplObjectStorage();
-                $entities[$entity] = $collection;
-                $this->fetchRelated($entity, $collection, $entities);
-                $this->postHydrate($entities);
-            }
-
-            $this->markTracked($entity, $collection);
             $result[] = $entity;
         }
 
@@ -105,11 +69,7 @@ final class InMemoryMapper extends AbstractMapper
         }
 
         foreach ($this->changed as $entity) {
-            if ($this->new->offsetExists($entity)) {
-                continue;
-            }
-
-            if ($this->removed->offsetExists($entity)) {
+            if ($this->new->offsetExists($entity) || $this->removed->offsetExists($entity)) {
                 continue;
             }
 
@@ -150,65 +110,76 @@ final class InMemoryMapper extends AbstractMapper
         $this->reset();
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
-    private function fetchRelated(object $parent, Collection $collection, SplObjectStorage $entities): void
+    protected function defaultHydrator(Collection $collection): Hydrator
     {
-        $next = $collection->next;
+        return new Nested();
+    }
 
-        if ($next !== null) {
-            $this->fetchRelatedCollection($parent, $next, $entities);
+    /** @param array<string, mixed> $row */
+    private function hydrateRow(array $row, Collection $collection): object|false
+    {
+        $raw = $this->rowToObject($row);
+        $this->attachRelated($raw, $collection);
+
+        $entities = $this->resolveHydrator($collection)->hydrate($raw, $collection, $this->entityFactory);
+        if ($entities === false) {
+            return false;
+        }
+
+        if ($entities->count() > 1) {
+            $this->postHydrate($entities);
+        }
+
+        foreach ($entities as $entity) {
+            $this->markTracked($entity, $entities[$entity]);
+        }
+
+        $entities->rewind();
+
+        return $entities->current();
+    }
+
+    private function attachRelated(stdClass $parentRaw, Collection $collection): void
+    {
+        if ($collection->next !== null) {
+            $this->attachChild($parentRaw, $collection->next);
         }
 
         foreach ($collection->children as $child) {
-            $this->fetchRelatedCollection($parent, $child, $entities);
+            $this->attachChild($parentRaw, $child);
         }
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
-    private function fetchRelatedCollection(
-        object $parent,
-        Collection $related,
-        SplObjectStorage $entities,
-    ): void {
-        $relatedName = (string) $related->name;
-        $fkCol = $this->style->remoteIdentifier($relatedName);
-        $fkValue = $this->entityFactory->get($parent, $fkCol);
+    private function attachChild(stdClass $parentRaw, Collection $child): void
+    {
+        $childName = (string) $child->name;
+        $fkValue = $parentRaw->{$this->style->remoteIdentifier($childName)} ?? null;
 
         if ($fkValue === null) {
             return;
         }
 
-        $pk = $this->style->identifier($relatedName);
-        $row = $this->findRowByPk($relatedName, $pk, $fkValue);
+        $pk = $this->style->identifier($childName);
+        $childRow = $this->findRowByPk($childName, $pk, $fkValue);
 
-        if ($row === null) {
+        if ($childRow === null) {
             return;
         }
 
-        $rowObject = $this->rowToObject($row);
-        $entityName = $related->resolveEntityName($this->entityFactory, $rowObject);
-        $childEntity = $this->entityFactory->createByName($entityName);
+        $childRaw = $this->rowToObject($childRow);
+        $parentRaw->{$childName} = $childRaw;
 
-        foreach ($row as $key => $value) {
-            $this->entityFactory->set($childEntity, $key, $value);
-        }
-
-        $entities[$childEntity] = $related;
-        $this->markTracked($childEntity, $related);
-
-        if (!$related->more) {
+        if (!$child->more) {
             return;
         }
 
-        $this->fetchRelated($childEntity, $related, $entities);
+        $this->attachRelated($childRaw, $child);
     }
 
     /** @return array<string, mixed>|null */
     private function findRow(string $table, mixed $condition): array|null
     {
-        $rows = $this->findRows($table, $condition);
-
-        return $rows[0] ?? null;
+        return $this->findRows($table, $condition)[0] ?? null;
     }
 
     /** @return list<array<string, mixed>> */
@@ -242,7 +213,7 @@ final class InMemoryMapper extends AbstractMapper
     }
 
     /** @param array<string, mixed> $row */
-    private function rowToObject(array $row): object
+    private function rowToObject(array $row): stdClass
     {
         $obj = new stdClass();
         foreach ($row as $key => $value) {


### PR DESCRIPTION
Add pluggable hydration strategies so collections can control how raw backend data is transformed into entity instances.

- Add Hydrator interface at Respect\Data\Hydrator with a single hydrate(mixed, Collection, EntityFactory) method
- Add abstract Flat hydrator using template method pattern: subclasses implement resolveColumnName() to map positions to column names; base handles entity shell building, PK-boundary reverse iteration, Composite duplication, and Typed entity resolution
- Add Nested hydrator for document-style backends: walks the collection tree extracting matching keys from a nested stdClass structure, pure data transformation with no I/O
- Add Collection::$hydrator property and hydrateFrom() fluent setter for per-collection hydration override
- Add AbstractMapper::resolveHydrator() with defaultHydrator() abstract hook — mappers advise the default strategy, users can override
- Move buildEntitiesInstances() from AbstractMapper into Flat hydrator
- Fix CollectionIterator::recursive() return type annotation to signal it yields Collection instances, removing need for instanceof guard
- Refactor InMemoryMapper to pre-assemble nested raw structures and delegate to Nested hydrator, with shared hydrateRow() method
- Add unit tests for Nested (9 tests) and Flat (7 tests) hydrators
- Add tests for Collection::hydrateFrom() and resolveEntityName()