### PR TITLE
Move FK wiring from AbstractMapper into Hydrators/Base

### DIFF
--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -110,42 +110,6 @@ abstract class AbstractMapper
         return $collection->hydrator ?? $this->defaultHydrator($collection);
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
-    protected function postHydrate(SplObjectStorage $entities): void
-    {
-        $entitiesClone = clone $entities;
-
-        foreach ($entities as $instance) {
-            foreach ($this->entityFactory->extractProperties($instance) as $field => $v) {
-                if (!$this->style->isRemoteIdentifier($field)) {
-                    continue;
-                }
-
-                foreach ($entitiesClone as $sub) {
-                    $this->tryHydration($entities, $sub, $field, $v);
-                }
-
-                $this->entityFactory->set($instance, $field, $v);
-            }
-        }
-    }
-
-    /** @param SplObjectStorage<object, Collection> $entities */
-    private function tryHydration(SplObjectStorage $entities, object $sub, string $field, mixed &$v): void
-    {
-        $tableName = (string) $entities[$sub]->name;
-        $primaryName = $this->style->identifier($tableName);
-
-        if (
-            $tableName !== $this->style->remoteFromIdentifier($field)
-                || $this->entityFactory->get($sub, $primaryName) != $v
-        ) {
-            return;
-        }
-
-        $v = $sub;
-    }
-
     public function __get(string $name): Collection
     {
         if (isset($this->collections[$name])) {

--- a/src/Hydrators/Base.php
+++ b/src/Hydrators/Base.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Respect\Data\Hydrators;
+
+use Respect\Data\Collections\Collection;
+use Respect\Data\EntityFactory;
+use Respect\Data\Hydrator;
+use SplObjectStorage;
+
+/** Base hydrator providing FK-to-entity wiring shared by all strategies */
+abstract class Base implements Hydrator
+{
+    /** @param SplObjectStorage<object, Collection> $entities */
+    protected function wireRelationships(SplObjectStorage $entities, EntityFactory $entityFactory): void
+    {
+        $style = $entityFactory->style;
+        $entitiesClone = clone $entities;
+
+        foreach ($entities as $instance) {
+            foreach ($entityFactory->extractProperties($instance) as $field => $v) {
+                if (!$style->isRemoteIdentifier($field)) {
+                    continue;
+                }
+
+                foreach ($entitiesClone as $sub) {
+                    $tableName = (string) $entities[$sub]->name;
+                    $primaryName = $style->identifier($tableName);
+
+                    if (
+                        $tableName !== $style->remoteFromIdentifier($field)
+                            || $entityFactory->get($sub, $primaryName) != $v
+                    ) {
+                        continue;
+                    }
+
+                    $v = $sub;
+                }
+
+                $entityFactory->set($instance, $field, $v);
+            }
+        }
+    }
+}

--- a/src/Hydrators/Flat.php
+++ b/src/Hydrators/Flat.php
@@ -9,8 +9,6 @@ use Respect\Data\Collections\Collection;
 use Respect\Data\Collections\Composite;
 use Respect\Data\Collections\Filtered;
 use Respect\Data\EntityFactory;
-use Respect\Data\Hydrator;
-use Respect\Data\Styles\Stylable;
 use SplObjectStorage;
 
 use function array_pop;
@@ -23,13 +21,8 @@ use function is_array;
  *
  * Subclasses define how column names are resolved from the raw data format.
  */
-abstract class Flat implements Hydrator
+abstract class Flat extends Base
 {
-    public function __construct(
-        private readonly Stylable $style,
-    ) {
-    }
-
     /** @return SplObjectStorage<object, Collection>|false */
     public function hydrate(
         mixed $raw,
@@ -52,12 +45,16 @@ abstract class Flat implements Hydrator
 
         foreach (array_reverse($raw, true) as $col => $value) {
             $columnName = $this->resolveColumnName($col, $raw);
-            $primaryName = $this->style->identifier(
+            $primaryName = $entityFactory->style->identifier(
                 (string) $entities[$entityInstance]->name,
             );
 
-            /** @phpstan-ignore argument.type */
-            $entityFactory->set($entityInstance, $columnName, $value);
+            $entityFactory->set(
+                /** @phpstan-ignore argument.type */
+                $entityInstance,
+                $columnName,
+                $value,
+            );
 
             if ($primaryName != $columnName) {
                 continue;
@@ -66,7 +63,13 @@ abstract class Flat implements Hydrator
             $entityInstance = array_pop($entitiesInstances);
         }
 
-        return $this->resolveTypedEntities($entities, $entityFactory);
+        $entities = $this->resolveTypedEntities($entities, $entityFactory);
+
+        if ($entities->count() > 1) {
+            $this->wireRelationships($entities, $entityFactory);
+        }
+
+        return $entities;
     }
 
     /** Resolve the column name for a given reference (numeric index, namespaced key, etc.) */

--- a/src/Hydrators/Nested.php
+++ b/src/Hydrators/Nested.php
@@ -6,14 +6,12 @@ namespace Respect\Data\Hydrators;
 
 use Respect\Data\Collections\Collection;
 use Respect\Data\EntityFactory;
-use Respect\Data\Hydrator;
 use SplObjectStorage;
 
-use function get_object_vars;
-use function is_object;
+use function is_array;
 
-/** Hydrates entities from a nested structure (object with sub-objects keyed by collection name) */
-final class Nested implements Hydrator
+/** Hydrates entities from a nested associative array keyed by collection name */
+final class Nested extends Base
 {
     /** @return SplObjectStorage<object, Collection>|false */
     public function hydrate(
@@ -21,57 +19,71 @@ final class Nested implements Hydrator
         Collection $collection,
         EntityFactory $entityFactory,
     ): SplObjectStorage|false {
-        if (!is_object($raw)) {
+        if (!is_array($raw)) {
             return false;
         }
 
         /** @var SplObjectStorage<object, Collection> $entities */
         $entities = new SplObjectStorage();
-        $entity = $entityFactory->hydrate($raw, $collection->resolveEntityName($entityFactory, $raw));
-        $entities[$entity] = $collection;
 
-        $this->hydrateRelated($raw, $collection, $entityFactory, $entities);
+        $this->hydrateNode($raw, $collection, $entityFactory, $entities);
+
+        if ($entities->count() > 1) {
+            $this->wireRelationships($entities, $entityFactory);
+        }
 
         return $entities;
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
-    private function hydrateRelated(
-        object $raw,
+    /**
+     * @param array<mixed, mixed> $data
+     * @param SplObjectStorage<object, Collection> $entities
+     */
+    private function hydrateNode(
+        array $data,
         Collection $collection,
         EntityFactory $entityFactory,
         SplObjectStorage $entities,
     ): void {
+        $entityName = $collection->resolveEntityName($entityFactory, (object) $data);
+        $entity = $entityFactory->createByName($entityName);
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                continue;
+            }
+
+            $entityFactory->set($entity, $key, $value);
+        }
+
+        $entities[$entity] = $collection;
+
         if ($collection->next !== null) {
-            $this->hydrateChild($raw, $collection->next, $entityFactory, $entities);
+            $this->hydrateChild($data, $collection->next, $entityFactory, $entities);
         }
 
         foreach ($collection->children as $child) {
-            $this->hydrateChild($raw, $child, $entityFactory, $entities);
+            $this->hydrateChild($data, $child, $entityFactory, $entities);
         }
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
+    /**
+     * @param array<string, mixed> $parentData
+     * @param SplObjectStorage<object, Collection> $entities
+     */
     private function hydrateChild(
-        object $parentRaw,
+        array $parentData,
         Collection $child,
         EntityFactory $entityFactory,
         SplObjectStorage $entities,
     ): void {
         $key = $child->name;
-        if ($key === null) {
+        if ($key === null || !isset($parentData[$key]) || !is_array($parentData[$key])) {
             return;
         }
 
-        $vars = get_object_vars($parentRaw);
-        if (!isset($vars[$key]) || !is_object($vars[$key])) {
-            return;
-        }
-
-        $childRaw = $vars[$key];
-        $entity = $entityFactory->hydrate($childRaw, $child->resolveEntityName($entityFactory, $childRaw));
-        $entities[$entity] = $child;
-
-        $this->hydrateRelated($childRaw, $child, $entityFactory, $entities);
+        /** @var array<string, mixed> $childData */
+        $childData = $parentData[$key];
+        $this->hydrateNode($childData, $child, $entityFactory, $entities);
     }
 }

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -231,7 +231,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function postHydrateReplacesFkWithMatchingEntity(): void
+    public function hydrationWiresFkWithMatchingEntity(): void
     {
         $mapper = new InMemoryMapper();
         $mapper->seed('comment', [
@@ -250,7 +250,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function postHydrateLeavesFkUnchangedWhenNoMatch(): void
+    public function hydrationLeavesFkUnchangedWhenNoMatch(): void
     {
         $mapper = new InMemoryMapper();
         $mapper->seed('comment', [
@@ -266,7 +266,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function postHydrateMatchesIntFkToStringPk(): void
+    public function hydrationMatchesIntFkToStringPk(): void
     {
         $mapper = new InMemoryMapper();
         $mapper->seed('comment', [

--- a/tests/Hydrators/FlatTest.php
+++ b/tests/Hydrators/FlatTest.php
@@ -12,8 +12,6 @@ use Respect\Data\Collections\Composite;
 use Respect\Data\Collections\Filtered;
 use Respect\Data\Collections\Typed;
 use Respect\Data\EntityFactory;
-use Respect\Data\Styles\Standard;
-use Respect\Data\Styles\Stylable;
 use stdClass;
 
 #[CoversClass(Flat::class)]
@@ -141,15 +139,13 @@ class FlatTest extends TestCase
     }
 
     /** @param list<string> $columnNames */
-    private function hydrator(array $columnNames, Stylable $style = new Standard()): Flat
+    private function hydrator(array $columnNames): Flat
     {
-        return new class ($columnNames, $style) extends Flat {
+        return new class ($columnNames) extends Flat {
             /** @param list<string> $columnNames */
             public function __construct(
                 private readonly array $columnNames,
-                Stylable $style,
             ) {
-                parent::__construct($style);
             }
 
             protected function resolveColumnName(mixed $reference, mixed $raw): string

--- a/tests/Hydrators/NestedTest.php
+++ b/tests/Hydrators/NestedTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\TestCase;
 use Respect\Data\Collections\Collection;
 use Respect\Data\Collections\Typed;
 use Respect\Data\EntityFactory;
-use stdClass;
 
 #[CoversClass(Nested::class)]
 class NestedTest extends TestCase
@@ -26,7 +25,7 @@ class NestedTest extends TestCase
     }
 
     #[Test]
-    public function hydrateReturnsFalseForNonObject(): void
+    public function hydrateReturnsFalseForNonArray(): void
     {
         $collection = Collection::author();
 
@@ -38,9 +37,7 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateSingleEntity(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->name = 'Author Name';
+        $raw = ['id' => 1, 'name' => 'Author Name'];
         $collection = Collection::author();
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
@@ -57,13 +54,11 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateWithNestedChild(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->title = 'Post Title';
-        $raw->author = new stdClass();
-        $raw->author->id = 5;
-        $raw->author->name = 'Author';
-
+        $raw = [
+            'id' => 1,
+            'title' => 'Post Title',
+            'author' => ['id' => 5, 'name' => 'Author'],
+        ];
         $collection = Collection::post()->author;
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
@@ -75,11 +70,7 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateWithMissingNestedKeyReturnsPartial(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->title = 'Post Title';
-        // no 'author' key
-
+        $raw = ['id' => 1, 'title' => 'Post Title'];
         $collection = Collection::post()->author;
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
@@ -91,16 +82,15 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateDeeplyNested(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->text = 'Comment';
-        $raw->post = new stdClass();
-        $raw->post->id = 10;
-        $raw->post->title = 'Post';
-        $raw->post->author = new stdClass();
-        $raw->post->author->id = 100;
-        $raw->post->author->name = 'Author';
-
+        $raw = [
+            'id' => 1,
+            'text' => 'Comment',
+            'post' => [
+                'id' => 10,
+                'title' => 'Post',
+                'author' => ['id' => 100, 'name' => 'Author'],
+            ],
+        ];
         $collection = Collection::comment()->post->author;
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
@@ -112,16 +102,12 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateWithChildren(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->title = 'Post';
-        $raw->author = new stdClass();
-        $raw->author->id = 5;
-        $raw->author->name = 'Author';
-        $raw->category = new stdClass();
-        $raw->category->id = 3;
-        $raw->category->label = 'Tech';
-
+        $raw = [
+            'id' => 1,
+            'title' => 'Post',
+            'author' => ['id' => 5, 'name' => 'Author'],
+            'category' => ['id' => 3, 'label' => 'Tech'],
+        ];
         $collection = Collection::post(Collection::author(), Collection::category());
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
@@ -133,15 +119,10 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateWithTypedCollection(): void
     {
-        $factory = new EntityFactory(entityNamespace: 'Respect\Data\Hydrators\\');
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->title = 'Issue';
-        $raw->type = 'stdClass';
-
+        $raw = ['id' => 1, 'title' => 'Issue', 'type' => 'stdClass'];
         $collection = Typed::by('type')->issue();
 
-        $result = $this->hydrator->hydrate($raw, $collection, $factory);
+        $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
 
         $this->assertNotFalse($result);
         $this->assertCount(1, $result);
@@ -150,9 +131,7 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateChildWithNullNameIsSkipped(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-
+        $raw = ['id' => 1];
         $child = new Collection();
         $collection = Collection::post($child);
 
@@ -165,10 +144,7 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateScalarNestedValueIsIgnored(): void
     {
-        $raw = new stdClass();
-        $raw->id = 1;
-        $raw->author = 'not-an-object';
-
+        $raw = ['id' => 1, 'author' => 'not-an-array'];
         $collection = Collection::post()->author;
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -6,7 +6,6 @@ namespace Respect\Data;
 
 use Respect\Data\Collections\Collection;
 use Respect\Data\Hydrators\Nested;
-use stdClass;
 
 use function array_filter;
 use function array_values;
@@ -118,16 +117,11 @@ final class InMemoryMapper extends AbstractMapper
     /** @param array<string, mixed> $row */
     private function hydrateRow(array $row, Collection $collection): object|false
     {
-        $raw = $this->rowToObject($row);
-        $this->attachRelated($raw, $collection);
+        $this->attachRelated($row, $collection);
 
-        $entities = $this->resolveHydrator($collection)->hydrate($raw, $collection, $this->entityFactory);
+        $entities = $this->resolveHydrator($collection)->hydrate($row, $collection, $this->entityFactory);
         if ($entities === false) {
             return false;
-        }
-
-        if ($entities->count() > 1) {
-            $this->postHydrate($entities);
         }
 
         foreach ($entities as $entity) {
@@ -139,21 +133,23 @@ final class InMemoryMapper extends AbstractMapper
         return $entities->current();
     }
 
-    private function attachRelated(stdClass $parentRaw, Collection $collection): void
+    /** @param array<string, mixed> $parentRow */
+    private function attachRelated(array &$parentRow, Collection $collection): void
     {
         if ($collection->next !== null) {
-            $this->attachChild($parentRaw, $collection->next);
+            $this->attachChild($parentRow, $collection->next);
         }
 
         foreach ($collection->children as $child) {
-            $this->attachChild($parentRaw, $child);
+            $this->attachChild($parentRow, $child);
         }
     }
 
-    private function attachChild(stdClass $parentRaw, Collection $child): void
+    /** @param array<string, mixed> $parentRow */
+    private function attachChild(array &$parentRow, Collection $child): void
     {
         $childName = (string) $child->name;
-        $fkValue = $parentRaw->{$this->style->remoteIdentifier($childName)} ?? null;
+        $fkValue = $parentRow[$this->style->remoteIdentifier($childName)] ?? null;
 
         if ($fkValue === null) {
             return;
@@ -166,14 +162,11 @@ final class InMemoryMapper extends AbstractMapper
             return;
         }
 
-        $childRaw = $this->rowToObject($childRow);
-        $parentRaw->{$childName} = $childRaw;
-
-        if (!$child->more) {
-            return;
+        if ($child->more) {
+            $this->attachRelated($childRow, $child);
         }
 
-        $this->attachRelated($childRaw, $child);
+        $parentRow[$childName] = $childRow;
     }
 
     /** @return array<string, mixed>|null */
@@ -210,16 +203,5 @@ final class InMemoryMapper extends AbstractMapper
         }
 
         return null;
-    }
-
-    /** @param array<string, mixed> $row */
-    private function rowToObject(array $row): stdClass
-    {
-        $obj = new stdClass();
-        foreach ($row as $key => $value) {
-            $obj->{$key} = $value;
-        }
-
-        return $obj;
     }
 }


### PR DESCRIPTION
- Add Hydrators/Base abstract class owning wireRelationships(), the FK-to-entity resolution algorithm previously in AbstractMapper
- Flat and Nested now extend Base instead of implementing Hydrator directly, calling wireRelationships() internally at end of hydrate()
- Hydrators now return fully wired entity trees — mappers no longer need to call postHydrate() after hydration
- Remove postHydrate() and tryHydration() from AbstractMapper
- Nested now receives Stylable in constructor (required by Base for FK identifier resolution during wiring)
- Flat keeps resolveTypedEntities() as private — only consumer, no premature abstraction into Base