### PR TITLE
Simplify Collection subtype DSL and improve type safety

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,7 @@ parameters:
     - src/
     - tests/
   ignoreErrors:
-    - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|Collections\\(Collection|Filtered|Composite|Typed))::\w+\(\)\./'
+    - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|InMemoryMapper|Collections\\(Collection|Filtered|Composite|Typed))::\w+\(\)\./'
     - message: '/Access to an undefined property Respect\\Data\\(AbstractMapper|InMemoryMapper|Collections\\Collection)::\$\w+\./'
     - message: '/Unsafe usage of new static\(\)\./'
     -

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -132,10 +132,17 @@ abstract class AbstractMapper
         $this->registerCollection($alias, $collection);
     }
 
-    /** @param array<int, mixed> $children */
-    public function __call(string $name, array $children): Collection
+    /** @param list<Collection|array<scalar, mixed>|scalar|null> $arguments */
+    public function __call(string $name, array $arguments): Collection
     {
-        $collection = Collection::__callstatic($name, $children);
+        if (isset($this->collections[$name])) {
+            $collection = clone $this->collections[$name];
+            $collection->mapper = $this;
+
+            return $collection->with(...$arguments);
+        }
+
+        $collection = Collection::__callstatic($name, $arguments);
         $collection->mapper = $this;
 
         return $collection;

--- a/src/Collections/Collection.php
+++ b/src/Collections/Collection.php
@@ -10,9 +10,6 @@ use Respect\Data\EntityFactory;
 use Respect\Data\Hydrator;
 use RuntimeException;
 
-use function is_array;
-use function is_scalar;
-
 /** @implements ArrayAccess<string, Collection> */
 class Collection implements ArrayAccess
 {
@@ -35,17 +32,15 @@ class Collection implements ArrayAccess
 
     public bool $more { get => $this->hasChildren || $this->next !== null; }
 
-    /** @param array<mixed>|scalar|null $condition */
+    /** @var array<scalar, mixed>|scalar|null */
+    public private(set) array|int|float|string|bool|null $condition = [];
+
+    /** @param (Collection|array<scalar, mixed>|scalar|null) ...$args */
     public function __construct(
         public private(set) string|null $name = null,
-        public private(set) array|int|float|string|bool|null $condition = [],
+        self|array|int|float|string|bool|null ...$args,
     ) {
-    }
-
-    /** @param array<mixed>|scalar|null $condition */
-    public static function using(array|int|float|string|bool|null $condition): static
-    {
-        return new static(condition: $condition);
+        $this->with(...$args);
     }
 
     public function addChild(Collection $child): void
@@ -120,6 +115,16 @@ class Collection implements ArrayAccess
         return $this;
     }
 
+    /** @param self|array<scalar, mixed>|scalar|null ...$arguments */
+    public function with(self|array|int|float|string|bool|null ...$arguments): static
+    {
+        foreach ($arguments as $arg) {
+            $arg instanceof Collection ? $this->addChild($arg) : $this->condition = $arg;
+        }
+
+        return $this;
+    }
+
     private function findMapper(): AbstractMapper|null
     {
         $node = $this;
@@ -145,12 +150,10 @@ class Collection implements ArrayAccess
         $this->next = $collection;
     }
 
-    /** @param array<int, mixed> $children */
-    public static function __callStatic(string $name, array $children): static
+    /** @param array<int, mixed> $arguments */
+    public static function __callStatic(string $name, array $arguments): static
     {
-        $collection = new static();
-
-        return $collection->__call($name, $children);
+        return new static($name, ...$arguments);
     }
 
     public function __get(string $name): static
@@ -163,22 +166,46 @@ class Collection implements ArrayAccess
         return $this->stack(new self($name));
     }
 
-    /** @param array<int, mixed> $children */
+    /** @param list<self|array<scalar, mixed>|scalar|null> $children */
     public function __call(string $name, array $children): static
     {
         if (!isset($this->name)) {
             $this->name = $name;
-            foreach ($children as $child) {
-                if ($child instanceof Collection) {
-                    $this->addChild($child);
-                } elseif (is_array($child) || is_scalar($child) || $child === null) {
-                    $this->condition = $child;
-                }
-            }
 
-            return $this;
+            return $this->with(...$children);
         }
 
         return $this->stack((new Collection())->__call($name, $children));
+    }
+
+    public function __clone(): void
+    {
+        if ($this->next !== null) {
+            $this->next = clone $this->next;
+            $this->next->parent = $this;
+        }
+
+        $clonedChildren = [];
+
+        foreach ($this->children as $child) {
+            $cloned = clone $child;
+            $cloned->parent = $this;
+            $clonedChildren[] = $cloned;
+        }
+
+        $this->children = $clonedChildren;
+        $this->parent = null;
+
+        if ($this->last === null) {
+            return;
+        }
+
+        $node = $this;
+
+        while ($node->next !== null) {
+            $node = $node->next;
+        }
+
+        $this->last = $node !== $this ? $node : null;
     }
 }

--- a/src/Collections/Composite.php
+++ b/src/Collections/Composite.php
@@ -6,29 +6,17 @@ namespace Respect\Data\Collections;
 
 final class Composite extends Collection
 {
-    /**
-     * @param array<string, list<string>> $compositions
-     * @param array<mixed>|scalar|null $condition
-     */
-    public function __construct(
-        public private(set) readonly array $compositions = [],
-        string|null $name = null,
-        array|int|float|string|bool|null $condition = [],
-    ) {
-        parent::__construct($name, $condition);
-    }
-
     /** @param array<string, list<string>> $compositions */
-    public static function with(array $compositions): static
-    {
-        return new static(compositions: $compositions);
+    public function __construct(
+        string $name,
+        public private(set) readonly array $compositions = [],
+    ) {
+        parent::__construct($name);
     }
 
-    /** @param array<int, mixed> $children */
-    public static function __callStatic(string $name, array $children): static
+    /** @param array<int, array<string, list<string>>> $arguments */
+    public static function __callStatic(string $name, array $arguments): static
     {
-        $collection = new static();
-
-        return $collection->__call($name, $children);
+        return new static($name, ...$arguments);
     }
 }

--- a/src/Collections/Filtered.php
+++ b/src/Collections/Filtered.php
@@ -14,28 +14,17 @@ final class Filtered extends Collection
     // phpcs:ignore PSR2.Classes.PropertyDeclaration
     public bool $identifierOnly { get => $this->filters === [self::IDENTIFIER_ONLY]; }
 
-    /**
-     * @param list<string> $filters
-     * @param array<mixed>|scalar|null $condition
-     */
+    /** @param list<string> $filters */
     public function __construct(
+        string $name,
         public private(set) readonly array $filters = [],
-        string|null $name = null,
-        array|int|float|string|bool|null $condition = [],
     ) {
-        parent::__construct($name, $condition);
+        parent::__construct($name);
     }
 
-    public static function by(string ...$names): static
+    /** @param array<scalar, string> $arguments */
+    public static function __callStatic(string $name, array $arguments): static
     {
-        return new static(filters: array_values($names));
-    }
-
-    /** @param array<int, mixed> $children */
-    public static function __callStatic(string $name, array $children): static
-    {
-        $collection = new static();
-
-        return $collection->__call($name, $children);
+        return new static($name, array_values($arguments));
     }
 }

--- a/src/Collections/Typed.php
+++ b/src/Collections/Typed.php
@@ -10,18 +10,11 @@ use function is_string;
 
 final class Typed extends Collection
 {
-    /** @param array<mixed>|scalar|null $condition */
     public function __construct(
+        string $name,
         public private(set) readonly string $type = '',
-        string|null $name = null,
-        array|int|float|string|bool|null $condition = [],
     ) {
-        parent::__construct($name, $condition);
-    }
-
-    public static function by(string $type): static
-    {
-        return new static(type: $type);
+        parent::__construct($name);
     }
 
     public function resolveEntityName(EntityFactory $factory, object $row): string
@@ -31,11 +24,9 @@ final class Typed extends Collection
         return is_string($name) ? $name : ($this->name ?? '');
     }
 
-    /** @param array<int, mixed> $children */
-    public static function __callStatic(string $name, array $children): static
+    /** @param array<int, string> $arguments */
+    public static function __callStatic(string $name, array $arguments): static
     {
-        $collection = new static();
-
-        return $collection->__call($name, $children);
+        return new static($name, ...$arguments);
     }
 }

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -284,6 +284,59 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
+    public function callingRegisteredCollectionClonesAndAppliesCondition(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('post', [
+            ['id' => 1, 'title' => 'Hello'],
+            ['id' => 2, 'title' => 'World'],
+        ]);
+
+        $mapper->postTitles = Filtered::posts('title');
+
+        $conditioned = $mapper->postTitles(['id' => 2]);
+
+        $this->assertInstanceOf(Filtered::class, $conditioned);
+        $this->assertEquals('posts', $conditioned->name);
+        $this->assertEquals(['title'], $conditioned->filters);
+        $this->assertEquals(['id' => 2], $conditioned->condition);
+        $this->assertEquals([], $mapper->postTitles->condition, 'Original collection should be unchanged');
+    }
+
+    #[Test]
+    public function callingRegisteredCollectionWithoutConditionReturnsClone(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->postTitles = Filtered::posts('title');
+
+        $clone = $mapper->postTitles();
+
+        $this->assertInstanceOf(Filtered::class, $clone);
+        $this->assertNotSame($mapper->postTitles, $clone);
+        $this->assertEquals('posts', $clone->name);
+        $this->assertEquals(['title'], $clone->filters);
+    }
+
+    #[Test]
+    public function callingRegisteredChainedCollectionDoesNotMutateTemplate(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('post', []);
+        $mapper->seed('comment', []);
+
+        $mapper->commentedPosts = Collection::posts()->comment();
+
+        $clone = $mapper->commentedPosts();
+        $clone->author; // stacks 'author' onto the clone's chain
+
+        $original = $mapper->commentedPosts;
+        $this->assertNull(
+            $original->next?->next,
+            'Stacking on a clone should not mutate the registered collection',
+        );
+    }
+
+    #[Test]
     public function filteredPersistDelegatesToParentCollection(): void
     {
         $mapper = new InMemoryMapper();

--- a/tests/CollectionIteratorTest.php
+++ b/tests/CollectionIteratorTest.php
@@ -75,7 +75,7 @@ class CollectionIteratorTest extends TestCase
     #[Test]
     public function getChildrenUseCollectionChildren(): void
     {
-        $coll = Collection::foo(Collection::bar(), Collection::baz());
+        $coll = Collection::foo()->with(Collection::bar(), Collection::baz());
         [$fooChild, $barChild] = $coll->children;
         $items = iterator_to_array(CollectionIterator::recursive($coll));
         $this->assertContains($fooChild, $items);

--- a/tests/Collections/CollectionTest.php
+++ b/tests/Collections/CollectionTest.php
@@ -297,14 +297,6 @@ class CollectionTest extends TestCase
     }
 
     #[Test]
-    public function usingShouldCreateCollectionWithCondition(): void
-    {
-        $coll = Collection::using(42);
-        $this->assertInstanceOf(Collection::class, $coll);
-        $this->assertEquals(42, $coll->condition);
-    }
-
-    #[Test]
     public function getParentShouldReturnNullWhenNoParent(): void
     {
         $coll = new Collection('foo');

--- a/tests/Collections/CompositeTest.php
+++ b/tests/Collections/CompositeTest.php
@@ -16,8 +16,8 @@ class CompositeTest extends TestCase
     #[Test]
     public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children1 = Composite::with(['foo' => ['bar']])->bar();
-        $children2 = Composite::with(['bat' => ['bar']])->baz()->bat();
+        $children1 = Composite::bar(['foo' => ['bar']]);
+        $children2 = Composite::baz(['bat' => ['bar']])->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
         $this->assertInstanceOf(Collection::class, $coll->next);

--- a/tests/Collections/FilteredTest.php
+++ b/tests/Collections/FilteredTest.php
@@ -16,8 +16,8 @@ class FilteredTest extends TestCase
     #[Test]
     public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children1 = Filtered::by('bar')->bar();
-        $children2 = Filtered::by('bat')->baz()->bat();
+        $children1 = Filtered::bar('bar');
+        $children2 = Filtered::baz('bat')->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
         $this->assertInstanceOf(Collection::class, $coll->next);
@@ -41,14 +41,14 @@ class FilteredTest extends TestCase
     #[Test]
     public function isIdentifierOnlyReturnsTrueForIdentifierOnlyFilter(): void
     {
-        $coll = Filtered::by(Filtered::IDENTIFIER_ONLY)->post();
+        $coll = Filtered::post(Filtered::IDENTIFIER_ONLY);
         $this->assertTrue($coll->identifierOnly);
     }
 
     #[Test]
     public function isIdentifierOnlyReturnsFalseForNamedFilters(): void
     {
-        $coll = Filtered::by('title')->post();
+        $coll = Filtered::post('title');
         $this->assertFalse($coll->identifierOnly);
     }
 

--- a/tests/Collections/TypedTest.php
+++ b/tests/Collections/TypedTest.php
@@ -18,8 +18,8 @@ class TypedTest extends TestCase
     #[Test]
     public function collectionCanBeCreatedStaticallyWithChildren(): void
     {
-        $children1 = Typed::by('a')->bar();
-        $children2 = Typed::by('b')->baz()->bat();
+        $children1 = Typed::bar('a');
+        $children2 = Typed::baz('b')->bat();
         $coll = Collection::foo($children1, $children2)->bar();
         $this->assertInstanceOf(Collection::class, $coll);
         $this->assertInstanceOf(Collection::class, $coll->next);
@@ -43,7 +43,7 @@ class TypedTest extends TestCase
     #[Test]
     public function resolveEntityNameReturnsDiscriminatorValue(): void
     {
-        $coll = Typed::by('type')->issues();
+        $coll = Typed::issues('type');
         $factory = new EntityFactory();
         $row = new stdClass();
         $row->type = 'Bug';
@@ -53,7 +53,7 @@ class TypedTest extends TestCase
     #[Test]
     public function resolveEntityNameFallsBackToCollectionName(): void
     {
-        $coll = Typed::by('type')->issues();
+        $coll = Typed::issues('type');
         $factory = new EntityFactory();
         $row = new stdClass();
         $this->assertEquals('issues', $coll->resolveEntityName($factory, $row));

--- a/tests/Hydrators/FlatTest.php
+++ b/tests/Hydrators/FlatTest.php
@@ -38,7 +38,7 @@ class FlatTest extends TestCase
     public function hydrateReturnsFalseWhenNoEntitiesBuilt(): void
     {
         $hydrator = $this->hydrator([]);
-        $filtered = Filtered::by()->post();
+        $filtered = Filtered::post();
 
         $this->assertFalse($hydrator->hydrate([1, 'value'], $filtered, $this->factory));
     }
@@ -85,7 +85,7 @@ class FlatTest extends TestCase
     public function hydrateSkipsUnfilteredFilteredCollections(): void
     {
         $hydrator = $this->hydrator(['id', 'title']);
-        $filtered = Filtered::by()->post();
+        $filtered = Filtered::post();
         $collection = Collection::author();
         $collection->stack($filtered);
 
@@ -99,7 +99,7 @@ class FlatTest extends TestCase
     public function hydrateFilteredCollectionWithFilters(): void
     {
         $hydrator = $this->hydrator(['id', 'name', 'id']);
-        $filtered = Filtered::by('name')->author();
+        $filtered = Filtered::author('name');
         $collection = Collection::post();
         $collection->stack($filtered);
 
@@ -114,7 +114,7 @@ class FlatTest extends TestCase
     {
         $factory = new EntityFactory(entityNamespace: 'Respect\Data\Hydrators\\');
         $hydrator = $this->hydrator(['id', 'type', 'title']);
-        $collection = Typed::by('type')->issue();
+        $collection = Typed::issue('type');
 
         $result = $hydrator->hydrate([1, 'stdClass', 'Bug Report'], $collection, $factory);
 
@@ -127,7 +127,7 @@ class FlatTest extends TestCase
     public function hydrateWithComposite(): void
     {
         $hydrator = $this->hydrator(['id', 'title', 'id', 'bio']);
-        $composite = Composite::with(['profile' => ['bio']])->author();
+        $composite = Composite::author(['profile' => ['bio']]);
 
         $result = $hydrator->hydrate([1, 'Author', 1, 'A bio'], $composite, $this->factory);
 

--- a/tests/Hydrators/NestedTest.php
+++ b/tests/Hydrators/NestedTest.php
@@ -120,7 +120,7 @@ class NestedTest extends TestCase
     public function hydrateWithTypedCollection(): void
     {
         $raw = ['id' => 1, 'title' => 'Issue', 'type' => 'stdClass'];
-        $collection = Typed::by('type')->issue();
+        $collection = Typed::issue('type');
 
         $result = $this->hydrator->hydrate($raw, $collection, $this->factory);
 


### PR DESCRIPTION
Replace verbose two-step factory patterns (Filtered::by()->name(), Composite::with()->name(), Typed::by()->name()) with direct static calls (Filtered::name(), Composite::name(), Typed::name()).

- Make $name the first, non-null constructor parameter on subtypes
- Remove $condition from subtype constructors
- Remove Filtered::by(), Composite::with(), Typed::by(), Collection::using()
- Extract with() from __call for shared arg processing
- Variadic constructor on Collection replaces separate condition param
- AbstractMapper::__call clones registered collections with conditions