### PR TITLE
Separate FK fields from relation properties in hydration

### DIFF
--- a/src/Hydrators/Base.php
+++ b/src/Hydrators/Base.php
@@ -9,6 +9,8 @@ use Respect\Data\EntityFactory;
 use Respect\Data\Hydrator;
 use SplObjectStorage;
 
+use function is_object;
+
 /** Base hydrator providing FK-to-entity wiring shared by all strategies */
 abstract class Base implements Hydrator
 {
@@ -25,6 +27,10 @@ abstract class Base implements Hydrator
                 }
 
                 foreach ($entitiesClone as $sub) {
+                    if ($sub === $instance) {
+                        continue;
+                    }
+
                     $tableName = (string) $entities[$sub]->name;
                     $primaryName = $style->identifier($tableName);
 
@@ -38,7 +44,16 @@ abstract class Base implements Hydrator
                     $v = $sub;
                 }
 
-                $entityFactory->set($instance, $field, $v);
+                if (!is_object($v)) {
+                    continue;
+                }
+
+                $relationName = $style->relationProperty($field);
+                if ($relationName === null) {
+                    continue;
+                }
+
+                $entityFactory->set($instance, $relationName, $v);
             }
         }
     }

--- a/src/Hydrators/Flat.php
+++ b/src/Hydrators/Flat.php
@@ -56,7 +56,7 @@ abstract class Flat extends Base
                 $value,
             );
 
-            if ($primaryName != $columnName) {
+            if ($primaryName != $columnName && !$this->isEntityBoundary($col, $raw)) {
                 continue;
             }
 
@@ -74,6 +74,12 @@ abstract class Flat extends Base
 
     /** Resolve the column name for a given reference (numeric index, namespaced key, etc.) */
     abstract protected function resolveColumnName(mixed $reference, mixed $raw): string;
+
+    /** Check if this column is the last one for the current entity (table boundary without PK) */
+    protected function isEntityBoundary(mixed $col, mixed $raw): bool
+    {
+        return false;
+    }
 
     /**
      * @param SplObjectStorage<object, Collection> $entities

--- a/src/Styles/NorthWind.php
+++ b/src/Styles/NorthWind.php
@@ -44,4 +44,14 @@ final class NorthWind extends Standard
     {
         return $this->isRemoteIdentifier($name) ? $this->singularToPlural(substr($name, 0, -2)) : null;
     }
+
+    public function relationProperty(string $field): string|null
+    {
+        return $this->isRemoteIdentifier($field) ? substr($field, 0, -2) : null;
+    }
+
+    public function isRelationProperty(string $name): bool
+    {
+        return !$this->isRemoteIdentifier($name) && $this->isRemoteIdentifier($name . 'ID');
+    }
 }

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -56,4 +56,14 @@ class Standard extends AbstractStyle
     {
         return $this->isRemoteIdentifier($name) ? substr($name, 0, -3) : null;
     }
+
+    public function relationProperty(string $field): string|null
+    {
+        return $this->isRemoteIdentifier($field) ? substr($field, 0, -3) : null;
+    }
+
+    public function isRelationProperty(string $name): bool
+    {
+        return !$this->isRemoteIdentifier($name) && $this->isRemoteIdentifier($name . '_id');
+    }
 }

--- a/src/Styles/Stylable.php
+++ b/src/Styles/Stylable.php
@@ -22,5 +22,9 @@ interface Stylable
 
     public function isRemoteIdentifier(string $name): bool;
 
+    public function relationProperty(string $remoteIdentifierField): string|null;
+
+    public function isRelationProperty(string $name): bool;
+
     public function composed(string $left, string $right): string;
 }

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -243,10 +243,46 @@ class AbstractMapperTest extends TestCase
 
         $comment = $mapper->comment->post->fetch();
         $this->assertIsObject($comment);
-        $post = $mapper->entityFactory->get($comment, 'post_id');
+        // FK stays as its original scalar value, never overwritten with an object
+        $fk = $mapper->entityFactory->get($comment, 'post_id');
+        $this->assertIsNotObject($fk);
+        $this->assertEquals(5, $fk);
+
+        // Related entity goes to the derived relation property
+        $post = $mapper->entityFactory->get($comment, 'post');
         $this->assertIsObject($post);
         $this->assertEquals(5, $mapper->entityFactory->get($post, 'id'));
         $this->assertEquals('Post', $mapper->entityFactory->get($post, 'title'));
+    }
+
+    #[Test]
+    public function persistAfterHydrationPreservesFkAndIgnoresRelation(): void
+    {
+        $mapper = new InMemoryMapper();
+        $mapper->seed('comment', [
+            ['id' => 1, 'text' => 'Hello', 'post_id' => 5],
+        ]);
+        $mapper->seed('post', [
+            ['id' => 5, 'title' => 'Post'],
+        ]);
+
+        // Fetch with relationship — hydrates $comment->post
+        $comment = $mapper->comment->post->fetch();
+        $this->assertIsObject($mapper->entityFactory->get($comment, 'post'));
+
+        // Modify and persist
+        $mapper->entityFactory->set($comment, 'text', 'Updated');
+        $mapper->comment->persist($comment);
+        $mapper->flush();
+
+        // Re-fetch without relationship
+        $updated = $mapper->comment[1]->fetch();
+        $this->assertEquals('Updated', $mapper->entityFactory->get($updated, 'text'));
+
+        // FK stayed as scalar
+        $fk = $mapper->entityFactory->get($updated, 'post_id');
+        $this->assertIsNotObject($fk);
+        $this->assertEquals(5, $fk);
     }
 
     #[Test]
@@ -278,7 +314,9 @@ class AbstractMapperTest extends TestCase
 
         $comment = $mapper->comment->post->fetch();
         $this->assertIsObject($comment);
-        $post = $mapper->entityFactory->get($comment, 'post_id');
+        // FK stays as int, relation goes to derived property
+        $this->assertEquals(5, $mapper->entityFactory->get($comment, 'post_id'));
+        $post = $mapper->entityFactory->get($comment, 'post');
         $this->assertIsObject($post);
         $this->assertEquals('5', $mapper->entityFactory->get($post, 'id'));
     }

--- a/tests/Styles/AbstractStyleTest.php
+++ b/tests/Styles/AbstractStyleTest.php
@@ -61,6 +61,16 @@ class AbstractStyleTest extends TestCase
             {
                 return null;
             }
+
+            public function relationProperty(string $field): string|null
+            {
+                return null;
+            }
+
+            public function isRelationProperty(string $name): bool
+            {
+                return false;
+            }
         };
     }
 

--- a/tests/Styles/CakePHP/CakePHPIntegrationTest.php
+++ b/tests/Styles/CakePHP/CakePHPIntegrationTest.php
@@ -59,7 +59,7 @@ class CakePHPIntegrationTest extends TestCase
 
         $categories = $mapper->post_categories->categories->fetch();
         $this->assertInstanceOf(PostCategory::class, $categories);
-        $this->assertInstanceOf(Category::class, $categories->category_id);
+        $this->assertInstanceOf(Category::class, $categories->category);
     }
 
     public function testFetchingAllEntityTypedNested(): void
@@ -67,8 +67,8 @@ class CakePHPIntegrationTest extends TestCase
         $mapper = $this->mapper;
         $comment = $mapper->comments->posts->authors->fetchAll();
         $this->assertInstanceOf(Comment::class, $comment[0]);
-        $this->assertInstanceOf(Post::class, $comment[0]->post_id);
-        $this->assertInstanceOf(Author::class, $comment[0]->post_id->author_id);
+        $this->assertInstanceOf(Post::class, $comment[0]->post);
+        $this->assertInstanceOf(Author::class, $comment[0]->post->author);
     }
 
     public function testPersistingEntityTyped(): void

--- a/tests/Styles/CakePHP/Comment.php
+++ b/tests/Styles/CakePHP/Comment.php
@@ -10,5 +10,7 @@ class Comment
 
     public mixed $post_id = null;
 
+    public mixed $post = null;
+
     public string|null $text = null;
 }

--- a/tests/Styles/CakePHP/Post.php
+++ b/tests/Styles/CakePHP/Post.php
@@ -13,4 +13,6 @@ class Post
     public string|null $text = null;
 
     public mixed $author_id = null;
+
+    public mixed $author = null;
 }

--- a/tests/Styles/CakePHP/PostCategory.php
+++ b/tests/Styles/CakePHP/PostCategory.php
@@ -11,4 +11,6 @@ class PostCategory
     public mixed $post_id = null;
 
     public mixed $category_id = null;
+
+    public mixed $category = null;
 }

--- a/tests/Styles/NorthWind/Comments.php
+++ b/tests/Styles/NorthWind/Comments.php
@@ -10,5 +10,7 @@ class Comments
 
     public mixed $PostID = null;
 
+    public mixed $Post = null;
+
     public string|null $Text = null;
 }

--- a/tests/Styles/NorthWind/NorthWindIntegrationTest.php
+++ b/tests/Styles/NorthWind/NorthWindIntegrationTest.php
@@ -59,7 +59,7 @@ class NorthWindIntegrationTest extends TestCase
 
         $categories = $mapper->PostCategories->Categories->fetch();
         $this->assertInstanceOf(PostCategories::class, $categories);
-        $this->assertInstanceOf(Categories::class, $categories->CategoryID);
+        $this->assertInstanceOf(Categories::class, $categories->Category);
     }
 
     public function testFetchingAllEntityTypedNested(): void
@@ -67,8 +67,8 @@ class NorthWindIntegrationTest extends TestCase
         $mapper = $this->mapper;
         $comment = $mapper->Comments->Posts->Authors->fetchAll();
         $this->assertInstanceOf(Comments::class, $comment[0]);
-        $this->assertInstanceOf(Posts::class, $comment[0]->PostID);
-        $this->assertInstanceOf(Authors::class, $comment[0]->PostID->AuthorID);
+        $this->assertInstanceOf(Posts::class, $comment[0]->Post);
+        $this->assertInstanceOf(Authors::class, $comment[0]->Post->Author);
     }
 
     public function testPersistingEntityTyped(): void

--- a/tests/Styles/NorthWind/PostCategories.php
+++ b/tests/Styles/NorthWind/PostCategories.php
@@ -11,4 +11,6 @@ class PostCategories
     public mixed $PostID = null;
 
     public mixed $CategoryID = null;
+
+    public mixed $Category = null;
 }

--- a/tests/Styles/NorthWind/Posts.php
+++ b/tests/Styles/NorthWind/Posts.php
@@ -13,4 +13,6 @@ class Posts
     public string|null $Text = null;
 
     public mixed $AuthorID = null;
+
+    public mixed $Author = null;
 }

--- a/tests/Styles/NorthWindTest.php
+++ b/tests/Styles/NorthWindTest.php
@@ -93,4 +93,35 @@ class NorthWindTest extends TestCase
         $this->assertEquals($foreign, $this->style->identifier($table));
         $this->assertEquals($foreign, $this->style->remoteIdentifier($table));
     }
+
+    /** @return array<int, array<int, string>> */
+    public static function relationProvider(): array
+    {
+        return [
+            ['Post',   'PostID'],
+            ['Author', 'AuthorID'],
+            ['Tag',    'TagID'],
+            ['User',   'UserID'],
+        ];
+    }
+
+    #[DataProvider('relationProvider')]
+    public function testRelationProperty(string $relation, string $foreign): void
+    {
+        $this->assertEquals($relation, $this->style->relationProperty($foreign));
+        $this->assertNull($this->style->relationProperty($relation));
+    }
+
+    #[DataProvider('relationProvider')]
+    public function testIsRelationProperty(string $relation, string $foreign): void
+    {
+        $this->assertTrue($this->style->isRelationProperty($relation));
+        $this->assertFalse($this->style->isRelationProperty($foreign));
+    }
+
+    #[DataProvider('relationProvider')]
+    public function testForeignKeyIsNotRelationProperty(string $relation, string $foreign): void
+    {
+        $this->assertFalse($this->style->isRelationProperty($foreign));
+    }
 }

--- a/tests/Styles/Plural/Comment.php
+++ b/tests/Styles/Plural/Comment.php
@@ -10,5 +10,7 @@ class Comment
 
     public mixed $post_id = null;
 
+    public mixed $post = null;
+
     public string|null $text = null;
 }

--- a/tests/Styles/Plural/PluralIntegrationTest.php
+++ b/tests/Styles/Plural/PluralIntegrationTest.php
@@ -59,7 +59,7 @@ class PluralIntegrationTest extends TestCase
 
         $categories = $mapper->posts_categories->categories->fetch();
         $this->assertInstanceOf(PostCategory::class, $categories);
-        $this->assertInstanceOf(Category::class, $categories->category_id);
+        $this->assertInstanceOf(Category::class, $categories->category);
     }
 
     public function testFetchingAllEntityTypedNested(): void
@@ -67,8 +67,8 @@ class PluralIntegrationTest extends TestCase
         $mapper = $this->mapper;
         $comment = $mapper->comments->posts->authors->fetchAll();
         $this->assertInstanceOf(Comment::class, $comment[0]);
-        $this->assertInstanceOf(Post::class, $comment[0]->post_id);
-        $this->assertInstanceOf(Author::class, $comment[0]->post_id->author_id);
+        $this->assertInstanceOf(Post::class, $comment[0]->post);
+        $this->assertInstanceOf(Author::class, $comment[0]->post->author);
     }
 
     public function testPersistingEntityTyped(): void

--- a/tests/Styles/Plural/Post.php
+++ b/tests/Styles/Plural/Post.php
@@ -13,4 +13,6 @@ class Post
     public string|null $text = null;
 
     public mixed $author_id = null;
+
+    public mixed $author = null;
 }

--- a/tests/Styles/Plural/PostCategory.php
+++ b/tests/Styles/Plural/PostCategory.php
@@ -11,4 +11,6 @@ class PostCategory
     public mixed $post_id = null;
 
     public mixed $category_id = null;
+
+    public mixed $category = null;
 }

--- a/tests/Styles/Sakila/Comment.php
+++ b/tests/Styles/Sakila/Comment.php
@@ -10,5 +10,7 @@ class Comment
 
     public mixed $post_id = null;
 
+    public mixed $post = null;
+
     public string|null $text = null;
 }

--- a/tests/Styles/Sakila/Post.php
+++ b/tests/Styles/Sakila/Post.php
@@ -13,4 +13,6 @@ class Post
     public string|null $text = null;
 
     public mixed $author_id = null;
+
+    public mixed $author = null;
 }

--- a/tests/Styles/Sakila/PostCategory.php
+++ b/tests/Styles/Sakila/PostCategory.php
@@ -11,4 +11,6 @@ class PostCategory
     public mixed $post_id = null;
 
     public mixed $category_id = null;
+
+    public mixed $category = null;
 }

--- a/tests/Styles/Sakila/SakilaIntegrationTest.php
+++ b/tests/Styles/Sakila/SakilaIntegrationTest.php
@@ -59,7 +59,7 @@ class SakilaIntegrationTest extends TestCase
 
         $categories = $mapper->post_category->category->fetch();
         $this->assertInstanceOf(PostCategory::class, $categories);
-        $this->assertInstanceOf(Category::class, $categories->category_id);
+        $this->assertInstanceOf(Category::class, $categories->category);
     }
 
     public function testFetchingAllEntityTypedNested(): void
@@ -67,8 +67,8 @@ class SakilaIntegrationTest extends TestCase
         $mapper = $this->mapper;
         $comment = $mapper->comment->post->author->fetchAll();
         $this->assertInstanceOf(Comment::class, $comment[0]);
-        $this->assertInstanceOf(Post::class, $comment[0]->post_id);
-        $this->assertInstanceOf(Author::class, $comment[0]->post_id->author_id);
+        $this->assertInstanceOf(Post::class, $comment[0]->post);
+        $this->assertInstanceOf(Author::class, $comment[0]->post->author);
     }
 
     public function testPersistingEntityTyped(): void

--- a/tests/Styles/StandardTest.php
+++ b/tests/Styles/StandardTest.php
@@ -93,4 +93,24 @@ class StandardTest extends TestCase
         $this->assertEquals($table, $this->style->remoteFromIdentifier($foreign));
         $this->assertEquals($foreign, $this->style->remoteIdentifier($table));
     }
+
+    #[DataProvider('foreignProvider')]
+    public function testRelationProperty(string $table, string $foreign): void
+    {
+        $this->assertEquals($table, $this->style->relationProperty($foreign));
+        $this->assertNull($this->style->relationProperty($table));
+    }
+
+    #[DataProvider('foreignProvider')]
+    public function testIsRelationProperty(string $table, string $foreign): void
+    {
+        $this->assertTrue($this->style->isRelationProperty($table));
+        $this->assertFalse($this->style->isRelationProperty($foreign));
+    }
+
+    #[DataProvider('foreignProvider')]
+    public function testForeignKeyIsNotRelationProperty(string $table, string $foreign): void
+    {
+        $this->assertFalse($this->style->isRelationProperty($foreign));
+    }
 }


### PR DESCRIPTION
wireRelationships() now sets related entities on a dedicated relation property (e.g. $comment->post) instead of overwriting the FK field ($comment->post_id stays as the int). This is driven by two new Style methods: relationProperty() derives the property name from an FK field, and isRelationProperty() identifies relation properties for filtering.

Flat hydrator gains an isEntityBoundary() hook so FlatNum can detect table transitions via column metadata, fixing hydration of join tables without a standalone id column.