### PR TITLE
Rename Collection to Scope, remove dead code, simplify API

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,7 @@ parameters:
     - src/
     - tests/
   ignoreErrors:
-    - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|InMemoryMapper|Collections\\Collection)::\w+\(\)\./'
+    - message: '/Call to an undefined (static )?method Respect\\Data\\(AbstractMapper|InMemoryMapper|Scope)::\w+\(\)\./'
     - message: '/Unsafe usage of new static\(\)\./'
     -
       message: '/Property .+ is never read, only written\./'

--- a/src/AbstractMapper.php
+++ b/src/AbstractMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Respect\Data;
 
-use Respect\Data\Collections\Collection;
 use SplObjectStorage;
 
 use function count;
@@ -15,17 +14,14 @@ use function is_string;
 
 abstract class AbstractMapper
 {
-    /** @var SplObjectStorage<object, Collection> Maps entity → source Collection */
+    /** @var SplObjectStorage<object, Scope> Maps entity → source Scope */
     protected SplObjectStorage $tracked;
 
     /** @var SplObjectStorage<object, string> Maps entity → 'insert'|'update'|'delete' */
     protected SplObjectStorage $pending;
 
-    /** @var array<string, array<int|string, object>> Identity-indexed map: [collectionName][idValue] → entity */
+    /** @var array<string, array<int|string, object>> Identity-indexed map: [scopeName][idValue] → entity */
     protected array $identityMap = [];
-
-    /** @var array<string, Collection> */
-    private array $collections = [];
 
     public EntityFactory $entityFactory { get => $this->hydrator->entityFactory; }
 
@@ -40,10 +36,10 @@ abstract class AbstractMapper
 
     abstract public function flush(): void;
 
-    abstract public function fetch(Collection $collection, mixed $extra = null): mixed;
+    abstract public function fetch(Scope $scope, mixed $extra = null): mixed;
 
     /** @return array<int, mixed> */
-    abstract public function fetchAll(Collection $collection, mixed $extra = null): array;
+    abstract public function fetchAll(Scope $scope, mixed $extra = null): array;
 
     public function reset(): void
     {
@@ -53,6 +49,40 @@ abstract class AbstractMapper
     public function clearIdentityMap(): void
     {
         $this->identityMap = [];
+    }
+
+    public function persist(object $object, Scope $onScope): object
+    {
+        if ($this->isTracked($object)) {
+            $currentOp = $this->pending[$object] ?? null;
+            if ($currentOp !== 'insert') {
+                $this->pending[$object] = 'update';
+            }
+
+            return $object;
+        }
+
+        $merged = $this->tryMergeWithIdentityMap($object, $onScope);
+        if ($merged !== null) {
+            return $merged;
+        }
+
+        $this->pending[$object] = 'insert';
+        $this->markTracked($object, $onScope);
+        $this->registerInIdentityMap($object, $onScope);
+
+        return $object;
+    }
+
+    public function remove(object $object, Scope $fromScope): void
+    {
+        $this->pending[$object] = 'delete';
+
+        if ($this->isTracked($object)) {
+            return;
+        }
+
+        $this->markTracked($object, $fromScope);
     }
 
     public function trackedCount(): int
@@ -70,45 +100,9 @@ abstract class AbstractMapper
         return $total;
     }
 
-    public function markTracked(object $entity, Collection $collection): bool
+    public function markTracked(object $entity, Scope $scope): void
     {
-        $this->tracked[$entity] = $collection;
-
-        return true;
-    }
-
-    public function persist(object $object, Collection $onCollection): object
-    {
-        if ($this->isTracked($object)) {
-            $currentOp = $this->pending[$object] ?? null;
-            if ($currentOp !== 'insert') {
-                $this->pending[$object] = 'update';
-            }
-
-            return $object;
-        }
-
-        $merged = $this->tryMergeWithIdentityMap($object, $onCollection);
-        if ($merged !== null) {
-            return $merged;
-        }
-
-        $this->pending[$object] = 'insert';
-        $this->markTracked($object, $onCollection);
-        $this->registerInIdentityMap($object, $onCollection);
-
-        return $object;
-    }
-
-    public function remove(object $object, Collection $fromCollection): bool
-    {
-        $this->pending[$object] = 'delete';
-
-        if (!$this->isTracked($object)) {
-            $this->markTracked($object, $fromCollection);
-        }
-
-        return true;
+        $this->tracked[$entity] = $scope;
     }
 
     public function isTracked(object $entity): bool
@@ -116,17 +110,8 @@ abstract class AbstractMapper
         return $this->tracked->offsetExists($entity);
     }
 
-    public function registerCollection(string $alias, Collection $collection): void
+    protected function registerInIdentityMap(object $entity, Scope $coll): void
     {
-        $this->collections[$alias] = $collection;
-    }
-
-    protected function registerInIdentityMap(object $entity, Collection $coll): void
-    {
-        if ($coll->name === null) {
-            return;
-        }
-
         $idValue = $this->entityIdValue($entity, $coll->name);
         if ($idValue === null) {
             return;
@@ -135,12 +120,8 @@ abstract class AbstractMapper
         $this->identityMap[$coll->name][$idValue] = $entity;
     }
 
-    protected function evictFromIdentityMap(object $entity, Collection $coll): void
+    protected function evictFromIdentityMap(object $entity, Scope $coll): void
     {
-        if ($coll->name === null) {
-            return;
-        }
-
         $idValue = $this->entityIdValue($entity, $coll->name);
         if ($idValue === null) {
             return;
@@ -149,26 +130,22 @@ abstract class AbstractMapper
         unset($this->identityMap[$coll->name][$idValue]);
     }
 
-    protected function findInIdentityMap(Collection $collection): object|null
+    protected function findInIdentityMap(Scope $scope): object|null
     {
-        if ($collection->name === null || !is_scalar($collection->filter) || $collection->hasChildren) {
+        if (!is_scalar($scope->filter) || $scope->hasChildren) {
             return null;
         }
 
-        $condition = $this->normalizeIdValue($collection->filter);
+        $condition = $this->normalizeIdValue($scope->filter);
         if ($condition === null) {
             return null;
         }
 
-        return $this->identityMap[$collection->name][$condition] ?? null;
+        return $this->identityMap[$scope->name][$condition] ?? null;
     }
 
-    private function tryMergeWithIdentityMap(object $entity, Collection $coll): object|null
+    private function tryMergeWithIdentityMap(object $entity, Scope $coll): object|null
     {
-        if ($coll->name === null) {
-            return null;
-        }
-
         $entityId = $this->entityIdValue($entity, $coll->name);
         $idValue = $entityId ?? $this->normalizeIdValue($coll->filter);
 
@@ -237,22 +214,9 @@ abstract class AbstractMapper
         return null;
     }
 
-    public function __isset(string $alias): bool
+    /** @param array<string, mixed> $arguments */
+    public function __call(string $name, array $arguments): Scope
     {
-        return isset($this->collections[$alias]);
-    }
-
-    /** @param list<mixed> $arguments */
-    public function __call(string $name, array $arguments): Collection
-    {
-        if (isset($this->collections[$name])) {
-            if (empty($arguments)) {
-                return clone $this->collections[$name];
-            }
-
-            return $this->collections[$name]->derive(...$arguments); // @phpstan-ignore argument.type
-        }
-
-        return new Collection($name, ...$arguments); // @phpstan-ignore argument.type
+        return new Scope($name, ...$arguments); // @phpstan-ignore argument.type
     }
 }

--- a/src/EntityFactory.php
+++ b/src/EntityFactory.php
@@ -203,17 +203,17 @@ class EntityFactory
     }
 
     /**
-     * Enumerate persistable fields for a collection, mapping DB column names to styled property names.
+     * Enumerate persistable fields for a scope, mapping DB column names to styled property names.
      *
      * @return array<string, string> DB column name → styled property name
      */
-    public function enumerateFields(string $collectionName): array
+    public function enumerateFields(string $scopeName): array
     {
-        if (isset($this->fieldCache[$collectionName])) {
-            return $this->fieldCache[$collectionName];
+        if (isset($this->fieldCache[$scopeName])) {
+            return $this->fieldCache[$scopeName];
         }
 
-        $class = $this->resolveClass($collectionName);
+        $class = $this->resolveClass($scopeName);
         $relations = $this->detectRelationProperties($class);
         $fields = [];
 
@@ -225,7 +225,7 @@ class EntityFactory
             $fields[$this->style->realProperty($name)] = $name;
         }
 
-        return $this->fieldCache[$collectionName] = $fields;
+        return $this->fieldCache[$scopeName] = $fields;
     }
 
     /**

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Respect\Data;
 
-use Respect\Data\Collections\Collection;
 use SplObjectStorage;
 
-/** Transforms raw backend data into entity instances mapped to their collections */
+/** Transforms raw backend data into entity instances mapped to their scopes */
 interface Hydrator
 {
     public EntityFactory $entityFactory { get; }
@@ -15,12 +14,12 @@ interface Hydrator
     /** Returns just the root entity */
     public function hydrate(
         mixed $raw,
-        Collection $collection,
+        Scope $scope,
     ): object|false;
 
-    /** @return SplObjectStorage<object, Collection>|false */
+    /** @return SplObjectStorage<object, Scope>|false */
     public function hydrateAll(
         mixed $raw,
-        Collection $collection,
+        Scope $scope,
     ): SplObjectStorage|false;
 }

--- a/src/Hydrators/Base.php
+++ b/src/Hydrators/Base.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Respect\Data\Hydrators;
 
 use DomainException;
-use Respect\Data\Collections\Collection;
 use Respect\Data\EntityFactory;
 use Respect\Data\Hydrator;
+use Respect\Data\Scope;
 use SplObjectStorage;
 
-/** Base hydrator providing collection-tree entity wiring */
+/** Base hydrator providing scope-tree entity wiring */
 abstract class Base implements Hydrator
 {
     public function __construct(
@@ -20,52 +20,52 @@ abstract class Base implements Hydrator
 
     public function hydrate(
         mixed $raw,
-        Collection $collection,
+        Scope $scope,
     ): object|false {
-        $entities = $this->hydrateAll($raw, $collection);
+        $entities = $this->hydrateAll($raw, $scope);
         if ($entities === false) {
             return false;
         }
 
         foreach ($entities as $entity) {
-            if ($entities[$entity] === $collection) {
+            if ($entities[$entity] === $scope) {
                 return $entity;
             }
         }
 
         throw new DomainException(
-            'Hydration produced no entity for collection "' . $collection->name . '"',
+            'Hydration produced no entity for scope "' . $scope->name . '"',
         );
     }
 
-    /** @param SplObjectStorage<object, Collection> $entities */
+    /** @param SplObjectStorage<object, Scope> $entities */
     protected function wireRelationships(SplObjectStorage $entities): void
     {
         $style = $this->entityFactory->style;
         $others = clone $entities;
 
         foreach ($entities as $entity) {
-            $coll = $entities[$entity];
+            $scope = $entities[$entity];
 
             foreach ($others as $other) {
                 if ($other === $entity) {
                     continue;
                 }
 
-                $otherColl = $others[$other];
-                if ($otherColl->parent !== $coll || $otherColl->name === null) {
+                $otherScope = $others[$other];
+                if ($otherScope->parent !== $scope) {
                     continue;
                 }
 
                 $relationName = $style->relationProperty(
-                    $style->remoteIdentifier($otherColl->name),
+                    $style->remoteIdentifier($otherScope->name),
                 );
 
                 if ($relationName === null) {
                     continue;
                 }
 
-                $id = $this->entityFactory->get($other, $style->identifier($otherColl->name));
+                $id = $this->entityFactory->get($other, $style->identifier($otherScope->name));
                 if ($id === null) {
                     continue;
                 }

--- a/src/Hydrators/Nested.php
+++ b/src/Hydrators/Nested.php
@@ -4,27 +4,27 @@ declare(strict_types=1);
 
 namespace Respect\Data\Hydrators;
 
-use Respect\Data\Collections\Collection;
+use Respect\Data\Scope;
 use SplObjectStorage;
 
 use function is_array;
 
-/** Hydrates entities from a nested associative array keyed by collection name */
+/** Hydrates entities from a nested associative array keyed by scope name */
 final class Nested extends Base
 {
-    /** @return SplObjectStorage<object, Collection>|false */
+    /** @return SplObjectStorage<object, Scope>|false */
     public function hydrateAll(
         mixed $raw,
-        Collection $collection,
+        Scope $scope,
     ): SplObjectStorage|false {
         if (!is_array($raw)) {
             return false;
         }
 
-        /** @var SplObjectStorage<object, Collection> $entities */
+        /** @var SplObjectStorage<object, Scope> $entities */
         $entities = new SplObjectStorage();
 
-        $this->hydrateNode($raw, $collection, $entities);
+        $this->hydrateNode($raw, $scope, $entities);
 
         if ($entities->count() > 1) {
             $this->wireRelationships($entities);
@@ -35,15 +35,15 @@ final class Nested extends Base
 
     /**
      * @param array<mixed, mixed> $data
-     * @param SplObjectStorage<object, Collection> $entities
+     * @param SplObjectStorage<object, Scope> $entities
      */
     private function hydrateNode(
         array $data,
-        Collection $collection,
+        Scope $scope,
         SplObjectStorage $entities,
     ): void {
         $entity = $this->entityFactory->create(
-            $this->entityFactory->resolveClass((string) $collection->name),
+            $this->entityFactory->resolveClass((string) $scope->name),
         );
 
         foreach ($data as $key => $value) {
@@ -54,24 +54,24 @@ final class Nested extends Base
             $this->entityFactory->set($entity, $key, $value);
         }
 
-        $entities[$entity] = $collection;
+        $entities[$entity] = $scope;
 
-        foreach ($collection->with as $child) {
+        foreach ($scope->with as $child) {
             $this->hydrateChild($data, $child, $entities);
         }
     }
 
     /**
      * @param array<string, mixed> $parentData
-     * @param SplObjectStorage<object, Collection> $entities
+     * @param SplObjectStorage<object, Scope> $entities
      */
     private function hydrateChild(
         array $parentData,
-        Collection $child,
+        Scope $child,
         SplObjectStorage $entities,
     ): void {
         $key = $child->name;
-        if ($key === null || !isset($parentData[$key]) || !is_array($parentData[$key])) {
+        if (!isset($parentData[$key]) || !is_array($parentData[$key])) {
             return;
         }
 

--- a/src/Hydrators/PrestyledAssoc.php
+++ b/src/Hydrators/PrestyledAssoc.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Respect\Data\Hydrators;
 
 use DomainException;
-use Respect\Data\CollectionIterator;
-use Respect\Data\Collections\Collection;
+use Respect\Data\Scope;
+use Respect\Data\ScopeIterator;
 use SplObjectStorage;
 
 use function explode;
@@ -21,21 +21,21 @@ use function is_array;
  */
 final class PrestyledAssoc extends Base
 {
-    /** @var array<string, Collection> */
-    private array $collMap = [];
+    /** @var array<string, Scope> */
+    private array $scopeMap = [];
 
-    private Collection|null $cachedCollection = null;
+    private Scope|null $cachedScope = null;
 
-    /** @return SplObjectStorage<object, Collection>|false */
+    /** @return SplObjectStorage<object, Scope>|false */
     public function hydrateAll(
         mixed $raw,
-        Collection $collection,
+        Scope $scope,
     ): SplObjectStorage|false {
         if (!$raw || !is_array($raw)) {
             return false;
         }
 
-        $collMap = $this->buildCollMap($collection);
+        $scopeMap = $this->buildScopeMap($scope);
 
         /** @var array<string, array<string, mixed>> $grouped */
         $grouped = [];
@@ -44,23 +44,23 @@ final class PrestyledAssoc extends Base
             $grouped[$prefix][$prop] = $value;
         }
 
-        /** @var SplObjectStorage<object, Collection> $entities */
+        /** @var SplObjectStorage<object, Scope> $entities */
         $entities = new SplObjectStorage();
         /** @var array<string, object> $instances */
         $instances = [];
 
         foreach ($grouped as $prefix => $props) {
-            if (!isset($collMap[$prefix])) {
+            if (!isset($scopeMap[$prefix])) {
                 throw new DomainException('Unknown column prefix "' . $prefix . '" in hydration row');
             }
 
             $basePrefix = $prefix;
 
             if (!isset($instances[$basePrefix])) {
-                $coll = $collMap[$basePrefix];
-                $class = $this->entityFactory->resolveClass((string) $coll->name);
+                $matched = $scopeMap[$basePrefix];
+                $class = $this->entityFactory->resolveClass((string) $matched->name);
                 $instances[$basePrefix] = $this->entityFactory->create($class);
-                $entities[$instances[$basePrefix]] = $coll;
+                $entities[$instances[$basePrefix]] = $matched;
             }
 
             $entity = $instances[$basePrefix];
@@ -76,20 +76,20 @@ final class PrestyledAssoc extends Base
         return $entities;
     }
 
-    /** @return array<string, Collection> */
-    private function buildCollMap(Collection $collection): array
+    /** @return array<string, Scope> */
+    private function buildScopeMap(Scope $scope): array
     {
-        if ($this->cachedCollection === $collection) {
-            return $this->collMap;
+        if ($this->cachedScope === $scope) {
+            return $this->scopeMap;
         }
 
-        $this->collMap = [];
-        foreach (CollectionIterator::recursive($collection) as $spec => $c) {
-            $this->collMap[$spec] = $c;
+        $this->scopeMap = [];
+        foreach (ScopeIterator::recursive($scope) as $spec => $c) {
+            $this->scopeMap[$spec] = $c;
         }
 
-        $this->cachedCollection = $collection;
+        $this->cachedScope = $scope;
 
-        return $this->collMap;
+        return $this->scopeMap;
     }
 }

--- a/src/Scope.php
+++ b/src/Scope.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace Respect\Data\Collections;
+namespace Respect\Data;
 
-class Collection
+class Scope
 {
-    public private(set) Collection|null $parent = null;
+    public private(set) Scope|null $parent = null;
 
-    /** @var list<Collection> */
+    /** @var list<Scope> */
     public private(set) array $with;
 
     public bool $hasChildren { get => !empty($this->with); }
 
     /**
-     * @param list<Collection> $with
+     * @param list<Scope> $with
      * @param array<scalar, mixed>|scalar|null $filter
      */
     public function __construct(
-        public readonly string|null $name = null,
+        public readonly string $name,
         array $with = [],
         public readonly array|int|float|string|bool|null $filter = null,
         public readonly bool $required = false,
@@ -27,26 +27,9 @@ class Collection
     }
 
     /**
-     * @param list<Collection> $with
-     * @param array<scalar, mixed>|scalar|null $filter
-     */
-    public function derive(
-        array $with = [],
-        array|int|float|string|bool|null $filter = null,
-        bool|null $required = null,
-    ): static {
-        return new static(
-            $this->name,
-            with: [...$this->with, ...$with],
-            filter: $filter ?? $this->filter,
-            required: $required ?? $this->required,
-        );
-    }
-
-    /**
-     * @param list<Collection> $children
+     * @param list<Scope> $children
      *
-     * @return list<Collection>
+     * @return list<Scope>
      */
     private function adoptChildren(array $children): array
     {

--- a/src/ScopeIterator.php
+++ b/src/ScopeIterator.php
@@ -6,22 +6,20 @@ namespace Respect\Data;
 
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
-use Respect\Data\Collections\Collection;
 
-use function array_filter;
 use function is_array;
 
-/** @extends RecursiveArrayIterator<array-key, Collection> */
-final class CollectionIterator extends RecursiveArrayIterator
+/** @extends RecursiveArrayIterator<array-key, Scope> */
+final class ScopeIterator extends RecursiveArrayIterator
 {
     /** @var array<string, int> */
     protected array $namesCounts = [];
 
     /**
-     * @param Collection|array<Collection> $target
+     * @param Scope|array<Scope> $target
      * @param array<string, int> $namesCounts
      */
-    public function __construct(Collection|array $target = [], array &$namesCounts = [])
+    public function __construct(Scope|array $target = [], array &$namesCounts = [])
     {
         $this->namesCounts = &$namesCounts;
 
@@ -30,15 +28,15 @@ final class CollectionIterator extends RecursiveArrayIterator
         parent::__construct($items);
     }
 
-    /** @return RecursiveIteratorIterator<CollectionIterator>&iterable<string, Collection> */
-    public static function recursive(Collection $target): RecursiveIteratorIterator
+    /** @return RecursiveIteratorIterator<ScopeIterator>&iterable<string, Scope> */
+    public static function recursive(Scope $target): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(new self($target), 1);
     }
 
     public function key(): string
     {
-        $name = $this->current()->name ?? '';
+        $name = $this->current()->name;
 
         if (isset($this->namesCounts[$name])) {
             return $name . ++$this->namesCounts[$name];
@@ -57,7 +55,7 @@ final class CollectionIterator extends RecursiveArrayIterator
     public function getChildren(): RecursiveArrayIterator
     {
         return new static(
-            array_filter($this->current()->with, static fn(Collection $c): bool => $c->name !== null),
+            $this->current()->with,
             $this->namesCounts,
         );
     }

--- a/src/Styles/Plural.php
+++ b/src/Styles/Plural.php
@@ -9,8 +9,6 @@ use function explode;
 use function implode;
 use function preg_match;
 use function preg_replace;
-use function strtolower;
-use function substr;
 use function ucfirst;
 
 /**
@@ -30,19 +28,6 @@ final class Plural extends Standard
         return $this->pluralToSingular($name) . '_id';
     }
 
-    public function remoteFromIdentifier(string $name): string|null
-    {
-        return $this->isRemoteIdentifier($name) ? $this->singularToPlural(substr($name, 0, -3)) : null;
-    }
-
-    public function realName(string $name): string
-    {
-        return implode('_', array_map(
-            $this->singularToPlural(...),
-            explode('_', strtolower($this->camelCaseToSeparator($name, '_'))),
-        ));
-    }
-
     public function styledName(string $name): string
     {
         $pieces = array_map($this->pluralToSingular(...), explode('_', $name));
@@ -57,28 +42,26 @@ final class Plural extends Standard
 
     private function pluralToSingular(string $name): string
     {
-        $replacements = [
+        return $this->applyFirstMatch($name, [
             '/^(.+)ies$/' => '$1y',
             '/^(.+)s$/' => '$1',
-        ];
-        foreach ($replacements as $key => $value) {
-            if (preg_match($key, $name)) {
-                return (string) preg_replace($key, $value, $name);
-            }
-        }
-
-        return $name;
+        ]);
     }
 
     private function singularToPlural(string $name): string
     {
-        $replacements = [
+        return $this->applyFirstMatch($name, [
             '/^(.+)y$/' => '$1ies',
             '/^(.+)([^s])$/' => '$1$2s',
-        ];
-        foreach ($replacements as $key => $value) {
-            if (preg_match($key, $name)) {
-                return (string) preg_replace($key, $value, $name);
+        ]);
+    }
+
+    /** @param array<string, string> $replacements */
+    private function applyFirstMatch(string $name, array $replacements): string
+    {
+        foreach ($replacements as $pattern => $replacement) {
+            if (preg_match($pattern, $name)) {
+                return (string) preg_replace($pattern, $replacement, $name);
             }
         }
 

--- a/src/Styles/Standard.php
+++ b/src/Styles/Standard.php
@@ -17,11 +17,6 @@ class Standard extends AbstractStyle
         return $this->separatorToCamelCase($name, '_');
     }
 
-    public function realName(string $name): string
-    {
-        return strtolower($this->camelCaseToSeparator($name, '_'));
-    }
-
     public function realProperty(string $name): string
     {
         return strtolower($this->camelCaseToSeparator($name, '_'));
@@ -52,18 +47,8 @@ class Standard extends AbstractStyle
         return strlen($name) - 3 === strripos($name, '_id');
     }
 
-    public function remoteFromIdentifier(string $name): string|null
-    {
-        return $this->isRemoteIdentifier($name) ? substr($name, 0, -3) : null;
-    }
-
     public function relationProperty(string $field): string|null
     {
         return $this->isRemoteIdentifier($field) ? substr($field, 0, -3) : null;
-    }
-
-    public function isRelationProperty(string $name): bool
-    {
-        return !$this->isRemoteIdentifier($name) && $this->isRemoteIdentifier($name . '_id');
     }
 }

--- a/src/Styles/Stylable.php
+++ b/src/Styles/Stylable.php
@@ -8,8 +8,6 @@ interface Stylable
 {
     public function styledName(string $entityName): string;
 
-    public function realName(string $styledName): string;
-
     public function styledProperty(string $name): string;
 
     public function realProperty(string $name): string;
@@ -18,13 +16,9 @@ interface Stylable
 
     public function remoteIdentifier(string $name): string;
 
-    public function remoteFromIdentifier(string $name): string|null;
-
     public function isRemoteIdentifier(string $name): bool;
 
     public function relationProperty(string $remoteIdentifierField): string|null;
-
-    public function isRelationProperty(string $name): bool;
 
     public function composed(string $left, string $right): string;
 }

--- a/tests/AbstractMapperTest.php
+++ b/tests/AbstractMapperTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
-use Respect\Data\Collections\Collection;
 use Respect\Data\Hydrators\Nested;
 use Respect\Data\Styles\Plural;
 use Respect\Data\Styles\Standard;
@@ -27,13 +26,13 @@ class AbstractMapperTest extends TestCase
             {
             }
 
-            public function fetch(Collection $collection, mixed $extra = null): mixed
+            public function fetch(Scope $scope, mixed $extra = null): mixed
             {
                 return false;
             }
 
             /** @return array<int, mixed> */
-            public function fetchAll(Collection $collection, mixed $extra = null): array
+            public function fetchAll(Scope $scope, mixed $extra = null): array
             {
                 return [];
             }
@@ -41,37 +40,14 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function registerCollectionShouldAddCollectionToPool(): void
+    public function magicCallShouldBypassToScope(): void
     {
-        $coll = Collection::foo();
-        $this->mapper->registerCollection('my_alias', $coll);
-
-        $this->assertTrue(isset($this->mapper->my_alias));
-        $clone = $this->mapper->my_alias();
-        $this->assertEquals($coll->name, $clone->name);
-    }
-
-    #[Test]
-    public function callingRegisteredCollectionWithoutArgsClones(): void
-    {
-        $coll = Collection::post();
-        $this->mapper->registerCollection('post', $coll);
-
-        $clone = $this->mapper->post();
-
-        $this->assertNotSame($coll, $clone);
-        $this->assertEquals('post', $clone->name);
-    }
-
-    #[Test]
-    public function magicCallShouldBypassToCollection(): void
-    {
-        $collection = $this->mapper->author([$this->mapper->post([$this->mapper->comment()])]);
-        $this->assertEquals('author', $collection->name);
-        $this->assertCount(1, $collection->with);
-        $this->assertEquals('post', $collection->with[0]->name);
-        $this->assertCount(1, $collection->with[0]->with);
-        $this->assertEquals('comment', $collection->with[0]->with[0]->name);
+        $scope = $this->mapper->author([$this->mapper->post([$this->mapper->comment()])]);
+        $this->assertEquals('author', $scope->name);
+        $this->assertCount(1, $scope->with);
+        $this->assertEquals('post', $scope->with[0]->name);
+        $this->assertCount(1, $scope->with[0]->with);
+        $this->assertEquals('comment', $scope->with[0]->with[0]->name);
     }
 
     #[Test]
@@ -98,13 +74,13 @@ class AbstractMapperTest extends TestCase
             {
             }
 
-            public function fetch(Collection $collection, mixed $extra = null): mixed
+            public function fetch(Scope $scope, mixed $extra = null): mixed
             {
                 return false;
             }
 
             /** @return array<int, mixed> */
-            public function fetchAll(Collection $collection, mixed $extra = null): array
+            public function fetchAll(Scope $scope, mixed $extra = null): array
             {
                 return [];
             }
@@ -116,8 +92,8 @@ class AbstractMapperTest extends TestCase
     public function persistShouldMarkObjectAsTracked(): void
     {
         $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $this->mapper->persist($entity, $collection);
+        $scope = Scope::foo();
+        $this->mapper->persist($entity, $scope);
         $this->assertTrue($this->mapper->isTracked($entity));
     }
 
@@ -125,9 +101,9 @@ class AbstractMapperTest extends TestCase
     public function persistAlreadyTrackedShouldReturnEntity(): void
     {
         $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $this->mapper->markTracked($entity, $collection);
-        $result = $this->mapper->persist($entity, $collection);
+        $scope = Scope::foo();
+        $this->mapper->markTracked($entity, $scope);
+        $result = $this->mapper->persist($entity, $scope);
         $this->assertSame($entity, $result);
     }
 
@@ -135,20 +111,19 @@ class AbstractMapperTest extends TestCase
     public function removeShouldMarkObjectAsTracked(): void
     {
         $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $result = $this->mapper->remove($entity, $collection);
-        $this->assertTrue($result);
+        $scope = Scope::foo();
+        $this->mapper->remove($entity, $scope);
         $this->assertTrue($this->mapper->isTracked($entity));
     }
 
     #[Test]
-    public function removeAlreadyTrackedShouldReturnTrue(): void
+    public function removeAlreadyTrackedShouldNotThrow(): void
     {
         $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $this->mapper->markTracked($entity, $collection);
-        $result = $this->mapper->remove($entity, $collection);
-        $this->assertTrue($result);
+        $scope = Scope::foo();
+        $this->mapper->markTracked($entity, $scope);
+        $this->mapper->remove($entity, $scope);
+        $this->assertTrue($this->mapper->isTracked($entity));
     }
 
     #[Test]
@@ -158,20 +133,12 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function markTrackedShouldReturnTrue(): void
-    {
-        $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $this->assertTrue($this->mapper->markTracked($entity, $collection));
-    }
-
-    #[Test]
     public function resetShouldClearPending(): void
     {
         $entity = new Stubs\Foo();
-        $collection = Collection::foo();
-        $this->mapper->persist($entity, $collection);
-        $this->mapper->remove($entity, $collection);
+        $scope = Scope::foo();
+        $this->mapper->persist($entity, $scope);
+        $this->mapper->remove($entity, $scope);
         $this->mapper->reset();
 
         $ref = new ReflectionObject($this->mapper);
@@ -180,20 +147,6 @@ class AbstractMapperTest extends TestCase
         /** @var SplObjectStorage<object, mixed> $pendingStorage */
         $pendingStorage = $pendingProp->getValue($this->mapper);
         $this->assertCount(0, $pendingStorage);
-    }
-
-    #[Test]
-    public function issetShouldReturnTrueForRegisteredCollection(): void
-    {
-        $coll = Collection::foo();
-        $this->mapper->registerCollection('my_alias', $coll);
-        $this->assertTrue(isset($this->mapper->my_alias));
-    }
-
-    #[Test]
-    public function issetShouldReturnFalseForUnregisteredCollection(): void
-    {
-        $this->assertFalse(isset($this->mapper->nonexistent));
     }
 
     #[Test]
@@ -212,7 +165,7 @@ class AbstractMapperTest extends TestCase
         $comment = $mapper->fetch($mapper->comment([$mapper->post()]));
         $this->assertIsObject($comment);
 
-        // Related entity wired via collection tree
+        // Related entity wired via scope tree
         $post = $mapper->entityFactory->get($comment, 'post');
         $this->assertIsObject($post);
         $this->assertEquals(5, $mapper->entityFactory->get($post, 'id'));
@@ -286,26 +239,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function callingRegisteredCollectionReturnsImmutableClone(): void
-    {
-        $mapper = new InMemoryMapper(new Nested(new EntityFactory(
-            entityNamespace: 'Respect\\Data\\Stubs\\',
-        )));
-        $mapper->seed('post', []);
-        $mapper->seed('comment', []);
-
-        $coll = Collection::posts();
-        $mapper->registerCollection('commentedPosts', $coll->derive(with: [Collection::comment()]));
-
-        $clone = $mapper->commentedPosts();
-
-        // Clone has the child from the registered collection
-        $this->assertCount(1, $clone->with);
-        $this->assertEquals('comment', $clone->with[0]->name);
-    }
-
-    #[Test]
-    public function directPersistWithoutRegisteredCollection(): void
+    public function directPersistWithoutRegisteredScope(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\',
@@ -494,23 +428,6 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function registerSkipsEntityWithNullCollectionName(): void
-    {
-        $mapper = new InMemoryMapper(new Nested(new EntityFactory(
-            entityNamespace: 'Respect\\Data\\Stubs\\',
-        )));
-        $entity = new Stubs\Foo();
-        $entity->id = 1;
-
-        // Collection with null name — register should be a no-op
-        $coll = new Collection();
-        $mapper->persist($entity, $coll);
-        $mapper->flush();
-
-        $this->assertSame(0, $mapper->identityMapCount());
-    }
-
-    #[Test]
     public function registerSkipsEntityWithNoPkValue(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
@@ -529,7 +446,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function deleteEvictsUsingTrackedCollection(): void
+    public function deleteEvictsUsingTrackedScope(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\',
@@ -541,29 +458,10 @@ class AbstractMapperTest extends TestCase
         $entity = $mapper->fetch($mapper->post(filter: 1));
         $this->assertSame(1, $mapper->identityMapCount());
 
-        // Remove via a different collection — flush uses the tracked one (name='post')
+        // Remove via a different scope — flush uses the tracked one (name='post')
         $mapper->remove($entity, $mapper->post());
         $mapper->flush();
 
-        $this->assertSame(0, $mapper->identityMapCount());
-    }
-
-    #[Test]
-    public function evictSkipsNullCollectionName(): void
-    {
-        $mapper = new InMemoryMapper(new Nested(new EntityFactory(
-            entityNamespace: 'Respect\\Data\\Stubs\\',
-        )));
-
-        // Track a new entity directly against a null-name collection
-        $entity = new Stubs\Foo();
-        $entity->id = 1;
-        $nullColl = new Collection();
-        $mapper->markTracked($entity, $nullColl);
-        $mapper->remove($entity, $nullColl);
-        $mapper->flush();
-
-        // Evict should be a no-op (null name), identity map stays empty
         $this->assertSame(0, $mapper->identityMapCount());
     }
 
@@ -609,7 +507,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function findInIdentityMapSkipsCollectionWithChildren(): void
+    public function findInIdentityMapSkipsScopeWithChildren(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\',
@@ -675,7 +573,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function persistReadOnlyViaCollectionPkUpdates(): void
+    public function persistReadOnlyViaScopePkUpdates(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\',
@@ -688,7 +586,7 @@ class AbstractMapperTest extends TestCase
         $fetched = $mapper->fetch($mapper->read_only_author(filter: 1));
         $this->assertSame('Original', $fetched->name);
 
-        // Create new readonly entity (no PK) and persist via collection[pk]
+        // Create new readonly entity (no PK) and persist via scope[pk]
         $updated = $mapper->entityFactory->create(Stubs\ReadOnlyAuthor::class, name: 'Updated', bio: 'new bio');
         $merged = $mapper->persist($updated, $mapper->read_only_author(filter: 1));
 
@@ -710,7 +608,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function persistReadOnlyViaCollectionPkFlushUpdatesStorage(): void
+    public function persistReadOnlyViaScopePkFlushUpdatesStorage(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\',
@@ -912,7 +810,7 @@ class AbstractMapperTest extends TestCase
     }
 
     #[Test]
-    public function readOnlyReplaceViaCollectionPkPreservesRelation(): void
+    public function readOnlyReplaceViaScopePkPreservesRelation(): void
     {
         $mapper = new InMemoryMapper(new Nested(new EntityFactory(
             entityNamespace: 'Respect\\Data\\Stubs\\Immutable\\',
@@ -1058,7 +956,7 @@ class AbstractMapperTest extends TestCase
 
         $updated = new Stubs\Immutable\Author(id: 1, name: 'Bob');
 
-        // persist via collection[1] — PK already set, merge produces new entity
+        // persist via scope[1] — PK already set, merge produces new entity
         $merged = $mapper->persist($updated, $mapper->author(filter: 1));
 
         $this->assertSame(1, $merged->id);
@@ -1289,15 +1187,5 @@ class AbstractMapperTest extends TestCase
         $this->assertSame('Updated', $merged->name);
         $this->assertTrue($mapper->isTracked($merged));
         $this->assertFalse($mapper->isTracked($fetched));
-    }
-
-    #[Test]
-    public function callingRegisteredCollectionWithArgsDerives(): void
-    {
-        $coll = Collection::post();
-        $this->mapper->registerCollection('post', $coll);
-        $derived = $this->mapper->post(filter: 5);
-        $this->assertEquals('post', $derived->name);
-        $this->assertEquals(5, $derived->filter);
     }
 }

--- a/tests/Hydrators/NestedTest.php
+++ b/tests/Hydrators/NestedTest.php
@@ -7,8 +7,8 @@ namespace Respect\Data\Hydrators;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Respect\Data\Collections\Collection;
 use Respect\Data\EntityFactory;
+use Respect\Data\Scope;
 
 #[CoversClass(Nested::class)]
 #[CoversClass(Base::class)]
@@ -27,20 +27,20 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateReturnsFalseForNonArray(): void
     {
-        $collection = Collection::author();
+        $scope = Scope::author();
 
-        $this->assertFalse($this->hydrator->hydrateAll(null, $collection));
-        $this->assertFalse($this->hydrator->hydrateAll(false, $collection));
-        $this->assertFalse($this->hydrator->hydrateAll('string', $collection));
+        $this->assertFalse($this->hydrator->hydrateAll(null, $scope));
+        $this->assertFalse($this->hydrator->hydrateAll(false, $scope));
+        $this->assertFalse($this->hydrator->hydrateAll('string', $scope));
     }
 
     #[Test]
     public function hydrateSingleEntity(): void
     {
         $raw = ['id' => 1, 'name' => 'Author Name'];
-        $collection = Collection::author();
+        $scope = Scope::author();
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(1, $result);
@@ -48,7 +48,7 @@ class NestedTest extends TestCase
         $entity = $result->current();
         $this->assertEquals(1, $this->factory->get($entity, 'id'));
         $this->assertEquals('Author Name', $this->factory->get($entity, 'name'));
-        $this->assertSame($collection, $result[$entity]);
+        $this->assertSame($scope, $result[$entity]);
     }
 
     #[Test]
@@ -59,9 +59,9 @@ class NestedTest extends TestCase
             'title' => 'Post Title',
             'author' => ['id' => 5, 'name' => 'Author'],
         ];
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(2, $result);
@@ -71,9 +71,9 @@ class NestedTest extends TestCase
     public function hydrateWithMissingNestedKeyReturnsPartial(): void
     {
         $raw = ['id' => 1, 'title' => 'Post Title'];
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(1, $result);
@@ -91,11 +91,11 @@ class NestedTest extends TestCase
                 'author' => ['id' => 100, 'name' => 'Author'],
             ],
         ];
-        $collection = Collection::comment([
-            Collection::post([Collection::author()]),
+        $scope = Scope::comment([
+            Scope::post([Scope::author()]),
         ]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(3, $result);
@@ -110,36 +110,23 @@ class NestedTest extends TestCase
             'author' => ['id' => 5, 'name' => 'Author'],
             'category' => ['id' => 3, 'label' => 'Tech'],
         ];
-        $authorColl = Collection::author();
-        $categoryColl = Collection::category();
-        $collection = Collection::post([$authorColl, $categoryColl]);
+        $authorColl = Scope::author();
+        $categoryColl = Scope::category();
+        $scope = Scope::post([$authorColl, $categoryColl]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(3, $result);
     }
 
     #[Test]
-    public function hydrateChildWithNullNameIsSkipped(): void
-    {
-        $raw = ['id' => 1];
-        $child = new Collection();
-        $collection = Collection::post([$child]);
-
-        $result = $this->hydrator->hydrateAll($raw, $collection);
-
-        $this->assertNotFalse($result);
-        $this->assertCount(1, $result);
-    }
-
-    #[Test]
     public function hydrateScalarNestedValueIsIgnored(): void
     {
         $raw = ['id' => 1, 'author' => 'not-an-array'];
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertCount(1, $result);
@@ -148,14 +135,14 @@ class NestedTest extends TestCase
     #[Test]
     public function hydrateReturnsFalseForInvalidInput(): void
     {
-        $this->assertFalse($this->hydrator->hydrate(null, Collection::author()));
+        $this->assertFalse($this->hydrator->hydrate(null, Scope::author()));
     }
 
     #[Test]
     public function hydrateReturnsRootEntity(): void
     {
         $raw = ['id' => 1, 'name' => 'Alice'];
-        $result = $this->hydrator->hydrate($raw, Collection::author());
+        $result = $this->hydrator->hydrate($raw, Scope::author());
 
         $this->assertNotFalse($result);
         $this->assertEquals(1, $this->factory->get($result, 'id'));
@@ -170,9 +157,9 @@ class NestedTest extends TestCase
             'title' => 'Post',
             'author' => ['name' => 'No ID'],
         ];
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
-        $result = $this->hydrator->hydrateAll($raw, $collection);
+        $result = $this->hydrator->hydrateAll($raw, $scope);
 
         $this->assertNotFalse($result);
         $result->rewind();
@@ -189,9 +176,9 @@ class NestedTest extends TestCase
             'title' => 'Post',
             'author' => ['id' => 5, 'name' => 'Author'],
         ];
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
-        $result = $this->hydrator->hydrate($raw, $collection);
+        $result = $this->hydrator->hydrate($raw, $scope);
 
         $this->assertNotFalse($result);
         $this->assertEquals(1, $this->factory->get($result, 'id'));

--- a/tests/Hydrators/PrestyledAssocTest.php
+++ b/tests/Hydrators/PrestyledAssocTest.php
@@ -8,8 +8,8 @@ use DomainException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Respect\Data\Collections\Collection;
 use Respect\Data\EntityFactory;
+use Respect\Data\Scope;
 use Respect\Data\Stubs\Author;
 
 #[CoversClass(PrestyledAssoc::class)]
@@ -27,7 +27,7 @@ class PrestyledAssocTest extends TestCase
     public function hydrateReturnsFalseForEmpty(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $coll = Collection::author();
+        $coll = Scope::author();
 
         $this->assertFalse($hydrator->hydrateAll(null, $coll));
         $this->assertFalse($hydrator->hydrateAll([], $coll));
@@ -38,11 +38,11 @@ class PrestyledAssocTest extends TestCase
     public function hydrateSingleEntity(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::author();
+        $scope = Scope::author();
 
         $result = $hydrator->hydrateAll(
             ['author__id' => 1, 'author__name' => 'Alice'],
-            $collection,
+            $scope,
         );
 
         $this->assertNotFalse($result);
@@ -57,7 +57,7 @@ class PrestyledAssocTest extends TestCase
     public function hydrateMultipleEntitiesFromJoinedRow(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::author([Collection::post()]);
+        $scope = Scope::author([Scope::post()]);
 
         $result = $hydrator->hydrateAll(
             [
@@ -67,7 +67,7 @@ class PrestyledAssocTest extends TestCase
                 'post__title' => 'Hello',
                 'post__author' => 1,
             ],
-            $collection,
+            $scope,
         );
 
         $this->assertNotFalse($result);
@@ -88,7 +88,7 @@ class PrestyledAssocTest extends TestCase
     public function hydrateWiresRelationships(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
         $result = $hydrator->hydrateAll(
             [
@@ -98,7 +98,7 @@ class PrestyledAssocTest extends TestCase
                 'author__id' => 1,
                 'author__name' => 'Alice',
             ],
-            $collection,
+            $scope,
         );
 
         $this->assertNotFalse($result);
@@ -113,7 +113,7 @@ class PrestyledAssocTest extends TestCase
     public function hydrateReturnsRootRegardlessOfColumnOrder(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::post([Collection::author()]);
+        $scope = Scope::post([Scope::author()]);
 
         // Author columns appear before post columns
         $result = $hydrator->hydrate(
@@ -124,7 +124,7 @@ class PrestyledAssocTest extends TestCase
                 'post__title' => 'Hello',
                 'post__author' => 1,
             ],
-            $collection,
+            $scope,
         );
 
         $this->assertNotFalse($result);
@@ -136,15 +136,15 @@ class PrestyledAssocTest extends TestCase
     public function hydrateCachesCollMapAcrossRows(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::author();
+        $scope = Scope::author();
 
         $first = $hydrator->hydrateAll(
             ['author__id' => 1, 'author__name' => 'Alice'],
-            $collection,
+            $scope,
         );
         $second = $hydrator->hydrateAll(
             ['author__id' => 2, 'author__name' => 'Bob'],
-            $collection,
+            $scope,
         );
 
         $this->assertNotFalse($first);
@@ -155,13 +155,13 @@ class PrestyledAssocTest extends TestCase
     public function hydrateThrowsOnUnknownPrefix(): void
     {
         $hydrator = new PrestyledAssoc($this->factory);
-        $collection = Collection::author();
+        $scope = Scope::author();
 
         $this->expectException(DomainException::class);
         $this->expectExceptionMessage('Unknown column prefix');
         $hydrator->hydrateAll(
             ['author__id' => 1, 'unknown__foo' => 'bar'],
-            $collection,
+            $scope,
         );
     }
 }

--- a/tests/InMemoryMapper.php
+++ b/tests/InMemoryMapper.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Respect\Data;
 
-use Respect\Data\Collections\Collection;
-
 use function array_filter;
 use function array_merge;
 use function array_values;
@@ -24,28 +22,28 @@ final class InMemoryMapper extends AbstractMapper
         $this->tables[$table] = $rows;
     }
 
-    public function fetch(Collection $collection, mixed $extra = null): mixed
+    public function fetch(Scope $scope, mixed $extra = null): mixed
     {
         if ($extra === null) {
-            $cached = $this->findInIdentityMap($collection);
+            $cached = $this->findInIdentityMap($scope);
             if ($cached !== null) {
                 return $cached;
             }
         }
 
-        $row = $this->findRow((string) $collection->name, $collection->filter);
+        $row = $this->findRow((string) $scope->name, $scope->filter);
 
-        return $row !== null ? $this->hydrateRow($row, $collection) : false;
+        return $row !== null ? $this->hydrateRow($row, $scope) : false;
     }
 
     /** @return array<int, mixed> */
-    public function fetchAll(Collection $collection, mixed $extra = null): array
+    public function fetchAll(Scope $scope, mixed $extra = null): array
     {
-        $rows = $this->findRows((string) $collection->name, $collection->filter);
+        $rows = $this->findRows((string) $scope->name, $scope->filter);
         $result = [];
 
         foreach ($rows as $row) {
-            $entity = $this->hydrateRow($row, $collection);
+            $entity = $this->hydrateRow($row, $scope);
             if ($entity === false) {
                 continue;
             }
@@ -60,28 +58,28 @@ final class InMemoryMapper extends AbstractMapper
     {
         foreach ($this->pending as $entity) {
             $op = $this->pending[$entity];
-            $collection = $this->tracked[$entity];
-            $tableName = (string) $collection->name;
+            $scope = $this->tracked[$entity];
+            $tableName = (string) $scope->name;
             $id = $this->style->identifier($tableName);
 
             match ($op) {
-                'insert' => $this->insertEntity($entity, $collection, $tableName, $id),
-                'update' => $this->updateEntity($entity, $collection, $tableName, $id),
+                'insert' => $this->insertEntity($entity, $scope, $tableName, $id),
+                'update' => $this->updateEntity($entity, $scope, $tableName, $id),
                 'delete' => $this->deleteEntity($entity, $tableName, $id),
                 default  => null,
             };
 
             if ($op === 'delete') {
-                $this->evictFromIdentityMap($entity, $collection);
+                $this->evictFromIdentityMap($entity, $scope);
             } else {
-                $this->registerInIdentityMap($entity, $collection);
+                $this->registerInIdentityMap($entity, $scope);
             }
         }
 
         $this->reset();
     }
 
-    private function insertEntity(object $entity, Collection $collection, string $tableName, string $id): void
+    private function insertEntity(object $entity, Scope $scope, string $tableName, string $id): void
     {
         $row = $this->entityFactory->extractColumns($entity);
 
@@ -94,7 +92,7 @@ final class InMemoryMapper extends AbstractMapper
         $this->tables[$tableName][] = $row;
     }
 
-    private function updateEntity(object $entity, Collection $collection, string $tableName, string $id): void
+    private function updateEntity(object $entity, Scope $scope, string $tableName, string $id): void
     {
         $idValue = $this->entityFactory->get($entity, $id);
         $row = $this->entityFactory->extractColumns($entity);
@@ -130,11 +128,11 @@ final class InMemoryMapper extends AbstractMapper
     }
 
     /** @param array<string, mixed> $row */
-    private function hydrateRow(array $row, Collection $collection): object|false
+    private function hydrateRow(array $row, Scope $scope): object|false
     {
-        $this->attachRelated($row, $collection);
+        $this->attachRelated($row, $scope);
 
-        $entities = $this->hydrator->hydrateAll($row, $collection);
+        $entities = $this->hydrator->hydrateAll($row, $scope);
         if ($entities === false) {
             return false;
         }
@@ -150,15 +148,15 @@ final class InMemoryMapper extends AbstractMapper
     }
 
     /** @param array<string, mixed> $parentRow */
-    private function attachRelated(array &$parentRow, Collection $collection): void
+    private function attachRelated(array &$parentRow, Scope $scope): void
     {
-        foreach ($collection->with as $child) {
+        foreach ($scope->with as $child) {
             $this->attachChild($parentRow, $child);
         }
     }
 
     /** @param array<string, mixed> $parentRow */
-    private function attachChild(array &$parentRow, Collection $child): void
+    private function attachChild(array &$parentRow, Scope $child): void
     {
         $childName = (string) $child->name;
         $refValue = $parentRow[$this->style->remoteIdentifier($childName)] ?? null;

--- a/tests/ScopeIteratorTest.php
+++ b/tests/ScopeIteratorTest.php
@@ -7,34 +7,33 @@ namespace Respect\Data;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Respect\Data\Collections\Collection;
 
 use function iterator_to_array;
 
-#[CoversClass(CollectionIterator::class)]
-class CollectionIteratorTest extends TestCase
+#[CoversClass(ScopeIterator::class)]
+class ScopeIteratorTest extends TestCase
 {
     #[Test]
     public function staticBuilderShouldCreateRecursiveIterator(): void
     {
         $this->assertInstanceOf(
             'RecursiveIteratorIterator',
-            CollectionIterator::recursive(Collection::foo()),
+            ScopeIterator::recursive(Scope::foo()),
         );
     }
 
     #[Test]
-    public function constructingShouldAcceptCollectionsOrArrays(): void
+    public function constructingShouldAcceptScopesOrArrays(): void
     {
-        $iterator = new CollectionIterator(Collection::foo());
-        $iterator2 = new CollectionIterator([Collection::foo()]);
+        $iterator = new ScopeIterator(Scope::foo());
+        $iterator2 = new ScopeIterator([Scope::foo()]);
         $this->assertEquals($iterator, $iterator2);
     }
 
     #[Test]
     public function keyShouldTrackNameCounts(): void
     {
-        $i = new CollectionIterator(Collection::foo());
+        $i = new ScopeIterator(Scope::foo());
         $this->assertEquals('foo', $i->key());
         $this->assertEquals('foo2', $i->key());
         $this->assertEquals('foo3', $i->key());
@@ -43,32 +42,32 @@ class CollectionIteratorTest extends TestCase
     #[Test]
     public function hasChildrenConsiderEmpties(): void
     {
-        $coll = Collection::foo();
-        $iterator = new CollectionIterator($coll);
+        $coll = Scope::foo();
+        $iterator = new ScopeIterator($coll);
         $this->assertFalse($iterator->hasChildren());
     }
 
     #[Test]
-    public function hasChildrenUseCollectionChildren(): void
+    public function hasChildrenUseScopeChildren(): void
     {
-        $coll = Collection::foo([Collection::bar()]);
-        $iterator = new CollectionIterator($coll);
+        $coll = Scope::foo([Scope::bar()]);
+        $iterator = new ScopeIterator($coll);
         $this->assertTrue($iterator->hasChildren());
     }
 
     #[Test]
     public function getChildrenConsiderEmpties(): void
     {
-        $coll = Collection::foo();
-        $iterator = new CollectionIterator($coll);
-        $this->assertEquals(new CollectionIterator(), $iterator->getChildren());
+        $coll = Scope::foo();
+        $iterator = new ScopeIterator($coll);
+        $this->assertEquals(new ScopeIterator(), $iterator->getChildren());
     }
 
     #[Test]
-    public function getChildrenUseCollectionWith(): void
+    public function getChildrenUseScopeWith(): void
     {
-        $coll = Collection::foo([Collection::bar(), Collection::baz()]);
-        $items = iterator_to_array(CollectionIterator::recursive($coll));
+        $coll = Scope::foo([Scope::bar(), Scope::baz()]);
+        $items = iterator_to_array(ScopeIterator::recursive($coll));
         $names = [];
         foreach ($items as $item) {
             $names[] = $item->name;
@@ -81,8 +80,8 @@ class CollectionIteratorTest extends TestCase
     #[Test]
     public function recursiveTraversalShouldVisitNestedChildren(): void
     {
-        $coll = Collection::foo([Collection::bar([Collection::baz()])]);
-        $items = iterator_to_array(CollectionIterator::recursive($coll));
+        $coll = Scope::foo([Scope::bar([Scope::baz()])]);
+        $items = iterator_to_array(ScopeIterator::recursive($coll));
         $this->assertCount(3, $items);
     }
 }

--- a/tests/Scopes/ScopeTest.php
+++ b/tests/Scopes/ScopeTest.php
@@ -2,51 +2,48 @@
 
 declare(strict_types=1);
 
-namespace Respect\Data\Collections;
+namespace Respect\Data;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Respect\Data\EntityFactory;
 use Respect\Data\Hydrators\Nested;
-use Respect\Data\InMemoryMapper;
-use Respect\Data\Stubs;
 
 use function count;
 
-#[CoversClass(Collection::class)]
-class CollectionTest extends TestCase
+#[CoversClass(Scope::class)]
+class ScopeTest extends TestCase
 {
     #[Test]
-    public function collectionCanBeCreatedStaticallyWithJustName(): void
+    public function scopeCanBeCreatedStaticallyWithJustName(): void
     {
-        $coll = Collection::fooBarName();
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
+        $coll = Scope::fooBarName();
+        $this->assertInstanceOf(Scope::class, $coll);
     }
 
     #[Test]
-    public function collectionCanBeCreatedStaticallyWithChildren(): void
+    public function scopeCanBeCreatedStaticallyWithChildren(): void
     {
-        $children1 = Collection::bar();
-        $children2 = Collection::baz();
-        $coll = Collection::foo([$children1, $children2]);
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
+        $children1 = Scope::bar();
+        $children2 = Scope::baz();
+        $coll = Scope::foo([$children1, $children2]);
+        $this->assertInstanceOf(Scope::class, $coll);
         $this->assertTrue($coll->hasChildren);
         $this->assertEquals(2, count($coll->with));
     }
 
     #[Test]
-    public function collectionCanBeCreatedStaticallyWithFilter(): void
+    public function scopeCanBeCreatedStaticallyWithFilter(): void
     {
-        $coll = Collection::fooBar(filter: 42);
-        $this->assertInstanceOf('Respect\Data\Collections\Collection', $coll);
+        $coll = Scope::fooBar(filter: 42);
+        $this->assertInstanceOf(Scope::class, $coll);
         $this->assertEquals(42, $coll->filter);
     }
 
     #[Test]
     public function objectConstructorShouldSetObjectAttributes(): void
     {
-        $coll = new Collection('some_irrelevant_name');
+        $coll = new Scope('some_irrelevant_name');
         $this->assertNull(
             $coll->filter,
             'Default filter should be null',
@@ -57,18 +54,18 @@ class CollectionTest extends TestCase
     #[Test]
     public function objectConstructorWithFilterShouldSetIt(): void
     {
-        $coll = new Collection('some_irrelevant_name', filter: 123);
+        $coll = new Scope('some_irrelevant_name', filter: 123);
         $this->assertEquals(123, $coll->filter);
     }
 
     #[Test]
     public function constructorCompositionShouldSetChildrenAndParent(): void
     {
-        $child = new Collection('bar_child');
-        $coll = new Collection('foo_collection', [$child]);
+        $child = new Scope('bar_child');
+        $coll = new Scope('foo_scope', [$child]);
         $children = $coll->with;
         $this->assertCount(1, $children);
-        $this->assertInstanceOf(Collection::class, $children[0]);
+        $this->assertInstanceOf(Scope::class, $children[0]);
         $this->assertEquals(false, $children[0]->required);
         $this->assertEquals($coll->name, $children[0]->parent?->name);
     }
@@ -76,56 +73,28 @@ class CollectionTest extends TestCase
     #[Test]
     public function childrenShouldMakeHasChildrenTrue(): void
     {
-        $coll = Collection::foo([Collection::thisIsAChildren()]);
+        $coll = Scope::foo([Scope::thisIsAChildren()]);
         $this->assertTrue($coll->hasChildren);
     }
 
     #[Test]
     public function noChildrenShouldMakeHasChildrenFalse(): void
     {
-        $coll = Collection::foo();
+        $coll = Scope::foo();
         $this->assertFalse($coll->hasChildren);
     }
 
     #[Test]
     public function getParentShouldReturnNullWhenNoParent(): void
     {
-        $coll = new Collection('foo');
+        $coll = new Scope('foo');
         $this->assertNull($coll->parent);
-    }
-
-    #[Test]
-    public function deriveCreatesNewCollectionWithMergedWith(): void
-    {
-        $original = Collection::foo([Collection::bar()]);
-        $derived = $original->derive(with: [Collection::baz()]);
-
-        $this->assertNotSame($original, $derived);
-        $this->assertEquals('foo', $derived->name);
-        $this->assertCount(2, $derived->with);
-        $this->assertEquals('bar', $derived->with[0]->name);
-        $this->assertEquals('baz', $derived->with[1]->name);
-        $this->assertCount(1, $original->with, 'Original should be unchanged');
-    }
-
-    #[Test]
-    public function derivePreservesFilterAndOverridesWhenProvided(): void
-    {
-        $original = new Collection('foo', filter: 42, required: true);
-
-        $sameFilter = $original->derive();
-        $this->assertEquals(42, $sameFilter->filter);
-        $this->assertTrue($sameFilter->required);
-
-        $newFilter = $original->derive(filter: 99, required: false);
-        $this->assertEquals(99, $newFilter->filter);
-        $this->assertFalse($newFilter->required);
     }
 
     #[Test]
     public function cloneDeepClonesChildrenAndClearsParent(): void
     {
-        $parent = Collection::foo([Collection::bar([Collection::baz()])]);
+        $parent = Scope::foo([Scope::bar([Scope::baz()])]);
         $clone = clone $parent;
 
         $this->assertNull($clone->parent);

--- a/tests/Styles/AbstractStyleTest.php
+++ b/tests/Styles/AbstractStyleTest.php
@@ -22,11 +22,6 @@ class AbstractStyleTest extends TestCase
                 return $name;
             }
 
-            public function realName(string $name): string
-            {
-                return $name;
-            }
-
             public function realProperty(string $name): string
             {
                 return $name;
@@ -57,19 +52,9 @@ class AbstractStyleTest extends TestCase
                 return false;
             }
 
-            public function remoteFromIdentifier(string $name): string|null
-            {
-                return null;
-            }
-
             public function relationProperty(string $field): string|null
             {
                 return null;
-            }
-
-            public function isRelationProperty(string $name): bool
-            {
-                return false;
             }
         };
     }

--- a/tests/Styles/PluralTest.php
+++ b/tests/Styles/PluralTest.php
@@ -67,7 +67,6 @@ class PluralTest extends TestCase
     public function testTableAndEntitiesMethods(string $table, string $entity): void
     {
         $this->assertEquals($entity, $this->style->styledName($table));
-        $this->assertEquals($table, $this->style->realName($entity));
         $this->assertEquals('id', $this->style->identifier($table));
     }
 
@@ -77,7 +76,6 @@ class PluralTest extends TestCase
         $this->assertEquals($column, $this->style->styledProperty($column));
         $this->assertEquals($column, $this->style->realProperty($column));
         $this->assertFalse($this->style->isRemoteIdentifier($column));
-        $this->assertNull($this->style->remoteFromIdentifier($column));
     }
 
     #[DataProvider('manyToManyTableProvider')]
@@ -90,7 +88,6 @@ class PluralTest extends TestCase
     public function testForeign(string $table, string $foreign): void
     {
         $this->assertTrue($this->style->isRemoteIdentifier($foreign));
-        $this->assertEquals($table, $this->style->remoteFromIdentifier($foreign));
         $this->assertEquals($foreign, $this->style->remoteIdentifier($table));
     }
 }

--- a/tests/Styles/StandardTest.php
+++ b/tests/Styles/StandardTest.php
@@ -67,7 +67,6 @@ class StandardTest extends TestCase
     public function testTableAndEntitiesMethods(string $table, string $entity): void
     {
         $this->assertEquals($entity, $this->style->styledName($table));
-        $this->assertEquals($table, $this->style->realName($entity));
         $this->assertEquals('id', $this->style->identifier($table));
     }
 
@@ -77,7 +76,6 @@ class StandardTest extends TestCase
         $this->assertEquals($name, $this->style->styledProperty($name));
         $this->assertEquals($name, $this->style->realProperty($name));
         $this->assertFalse($this->style->isRemoteIdentifier($name));
-        $this->assertNull($this->style->remoteFromIdentifier($name));
     }
 
     #[DataProvider('manyToManyTableProvider')]
@@ -90,7 +88,6 @@ class StandardTest extends TestCase
     public function testForeign(string $table, string $foreign): void
     {
         $this->assertTrue($this->style->isRemoteIdentifier($foreign));
-        $this->assertEquals($table, $this->style->remoteFromIdentifier($foreign));
         $this->assertEquals($foreign, $this->style->remoteIdentifier($table));
     }
 
@@ -99,18 +96,5 @@ class StandardTest extends TestCase
     {
         $this->assertEquals($table, $this->style->relationProperty($foreign));
         $this->assertNull($this->style->relationProperty($table));
-    }
-
-    #[DataProvider('foreignProvider')]
-    public function testIsRelationProperty(string $table, string $foreign): void
-    {
-        $this->assertTrue($this->style->isRelationProperty($table));
-        $this->assertFalse($this->style->isRelationProperty($foreign));
-    }
-
-    #[DataProvider('foreignProvider')]
-    public function testForeignKeyIsNotRelationProperty(string $table, string $foreign): void
-    {
-        $this->assertFalse($this->style->isRelationProperty($foreign));
     }
 }


### PR DESCRIPTION
- Rename Collection to Scope, CollectionIterator to ScopeIterator, move out of Collections sub-namespace
- Make Scope::$name non-null, remove all null-name guards
- Remove registerScope, __isset, derive (unused after simplification)
- Remove unused Stylable methods: realName, remoteFromIdentifier, isRelationProperty
- Simplify __call to a one-liner Scope factory
- Extract applyFirstMatch helper in Plural to deduplicate loops